### PR TITLE
State machine tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,12 +23,16 @@ jobs:
             go test ./...
             CI=true /go/bin/ginkgo -v --race \
             --cover --coverprofile coverprofile.out ./...
-            /go/bin/covermerge block/coverprofile.out \
-              cmd/node/coverprofile.out \
-              replica/coverprofile.out \
-              sig/coverprofile.out \
-              sig/ecdsa/coverprofile.out \
-              supervisor/coverprofile.out > coverprofile.out
+            /go/bin/covermerge 
+              block/coverprofile.out          \
+              cmd/hyperdrive/coverprofile.out \
+              consensus/coverprofile.out      \
+              replica/coverprofile.out        \
+              shard/coverprofile.out          \
+              sig/ecdsa/coverprofile.out      \
+              sig/coverprofile.out            \
+              supervisor/coverprofile.out     \
+              tx/coverprofile.out > coverprofile.out
       - save_cache:
           key: go-mod-v3-{{ checksum "go.sum" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
             go test ./...
             CI=true /go/bin/ginkgo -v --race \
             --cover --coverprofile coverprofile.out ./...
-            /go/bin/covermerge 
+            /go/bin/covermerge                \
               block/coverprofile.out          \
               cmd/hyperdrive/coverprofile.out \
               consensus/coverprofile.out      \

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -9,9 +9,13 @@
 
 go build ./...
 GOMAXPROCS=1 CI=true ginkgo -v --race --cover --coverprofile coverprofile.out ./...
-covermerge block/coverprofile.out \
-  cmd/node/coverprofile.out \
-  replica/coverprofile.out \
-  sig/coverprofile.out \
-  sig/ecdsa/coverprofile.out \
-  supervisor/coverprofile.out > coverprofile.out
+covermerge 
+  block/coverprofile.out          \
+  cmd/hyperdrive/coverprofile.out \
+  consensus/coverprofile.out      \
+  replica/coverprofile.out        \
+  shard/coverprofile.out          \
+  sig/ecdsa/coverprofile.out      \
+  sig/coverprofile.out            \
+  supervisor/coverprofile.out     \
+  tx/coverprofile.out > coverprofile.out

--- a/block/block.go
+++ b/block/block.go
@@ -48,6 +48,18 @@ type Blockchain struct {
 	tail map[sig.Hash]Commit
 }
 
+func NewBlockchain() Blockchain {
+	genesis := Genesis()
+	return Blockchain{
+		head: Commit{
+			Polka: Polka{
+				Block: &genesis,
+			},
+		},
+		tail: map[sig.Hash]Commit{},
+	}
+}
+
 func (blockchain *Blockchain) Height() Height {
 	if blockchain.head.Polka.Block == nil {
 		return Genesis().Height

--- a/block/commit.go
+++ b/block/commit.go
@@ -49,11 +49,11 @@ type Commit struct {
 type CommitBuilder map[Height]map[sig.Signatory]SignedPreCommit
 
 func (builder CommitBuilder) Insert(preCommit SignedPreCommit) {
-	if _, ok := builder[preCommit.Polka.Block.Height]; !ok {
-		builder[preCommit.Polka.Block.Height] = map[sig.Signatory]SignedPreCommit{}
+	if _, ok := builder[preCommit.Polka.Height]; !ok {
+		builder[preCommit.Polka.Height] = map[sig.Signatory]SignedPreCommit{}
 	}
-	if _, ok := builder[preCommit.Polka.Block.Height][preCommit.Signatory]; !ok {
-		builder[preCommit.Polka.Block.Height][preCommit.Signatory] = preCommit
+	if _, ok := builder[preCommit.Polka.Height][preCommit.Signatory]; !ok {
+		builder[preCommit.Polka.Height][preCommit.Signatory] = preCommit
 	}
 }
 
@@ -61,7 +61,7 @@ func (builder CommitBuilder) Commit(consensusThreshold int64) (Commit, bool) {
 	highestCommitFound := false
 	highestCommit := Commit{}
 	for height, preCommits := range builder {
-		if !highestCommitFound || height > highestCommit.Polka.Block.Height {
+		if !highestCommitFound || height > highestCommit.Polka.Height {
 			if int64(len(preCommits)) < consensusThreshold {
 				continue
 			}

--- a/block/polka.go
+++ b/block/polka.go
@@ -87,11 +87,11 @@ type PolkaBuilder map[Height]map[sig.Signatory]SignedPreVote
 // give this duplicate valid SignedPreVote and only one vote will be
 // registered.
 func (builder PolkaBuilder) Insert(preVote SignedPreVote) {
-	if _, ok := builder[preVote.Block.Height]; !ok {
-		builder[preVote.Block.Height] = map[sig.Signatory]SignedPreVote{}
+	if _, ok := builder[preVote.Height]; !ok {
+		builder[preVote.Height] = map[sig.Signatory]SignedPreVote{}
 	}
-	if _, ok := builder[preVote.Block.Height][preVote.Signatory]; !ok {
-		builder[preVote.Block.Height][preVote.Signatory] = preVote
+	if _, ok := builder[preVote.Height][preVote.Signatory]; !ok {
+		builder[preVote.Height][preVote.Signatory] = preVote
 	}
 }
 
@@ -105,7 +105,7 @@ func (builder PolkaBuilder) Polka(consensusThreshold int64) (Polka, bool) {
 	highestPolkaFound := false
 	highestPolka := Polka{}
 	for height, preVotes := range builder {
-		if !highestPolkaFound || height > highestPolka.Block.Height {
+		if !highestPolkaFound || height > highestPolka.Height {
 			if int64(len(preVotes)) < consensusThreshold {
 				continue
 			}

--- a/consensus/consensus_suite_test.go
+++ b/consensus/consensus_suite_test.go
@@ -1,0 +1,13 @@
+package consensus_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestConsensus(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Consensus Suite")
+}

--- a/consensus/state_machine.go
+++ b/consensus/state_machine.go
@@ -120,8 +120,8 @@ func (stateMachine *stateMachine) reducePreVoted(currentState State, preVoted Pr
 	return WaitForPolka(currentState.Round(), currentState.Height()), PreVote{
 		PreVote: block.PreVote{
 			Block:  preVoted.Block,
-			Round:  preVoted.Block.Round,
-			Height: preVoted.Block.Height,
+			Round:  preVoted.Round,
+			Height: preVoted.Height,
 		},
 	}
 }

--- a/consensus/state_machine_test.go
+++ b/consensus/state_machine_test.go
@@ -16,8 +16,7 @@ import (
 
 var _ = Describe("State Machine", func() {
 
-	polkaBuilder := make(map[block.Height]map[sig.Signatory]block.SignedPreVote)
-	stateMachine := NewStateMachine(polkaBuilder, block.CommitBuilder{}, 2)
+	stateMachine := NewStateMachine(block.PolkaBuilder{}, block.CommitBuilder{}, 2)
 
 	testCases := generateTestCases()
 

--- a/consensus/state_machine_test.go
+++ b/consensus/state_machine_test.go
@@ -177,7 +177,7 @@ func generateTestCases() []TestCase {
 			inputTransition: PreCommitted{
 				block.SignedPreCommit{
 					PreCommit: block.PreCommit{
-						block.Polka{
+						Polka: block.Polka{
 							Block: &genesis,
 						},
 					},
@@ -205,7 +205,7 @@ func generateTestCases() []TestCase {
 			inputTransition: PreCommitted{
 				block.SignedPreCommit{
 					PreCommit: block.PreCommit{
-						block.Polka{
+						Polka: block.Polka{
 							Block: &genesis,
 						},
 					},
@@ -327,7 +327,7 @@ func generateTestCases() []TestCase {
 			inputTransition: PreCommitted{
 				block.SignedPreCommit{
 					PreCommit: block.PreCommit{
-						block.Polka{
+						Polka: block.Polka{
 							Block: &block.Block{
 								Height: 0,
 								Round:  0,
@@ -354,7 +354,7 @@ func generateTestCases() []TestCase {
 			inputTransition: PreCommitted{
 				block.SignedPreCommit{
 					PreCommit: block.PreCommit{
-						block.Polka{
+						Polka: block.Polka{
 							Block: &block.Block{
 								Height: 0,
 								Round:  0,
@@ -426,7 +426,7 @@ func generateTestCases() []TestCase {
 			inputTransition: PreCommitted{
 				block.SignedPreCommit{
 					PreCommit: block.PreCommit{
-						block.Polka{
+						Polka: block.Polka{
 							Block: &block.Block{
 								Height: 0,
 								Round:  0,
@@ -512,7 +512,7 @@ func generateTestCases() []TestCase {
 			inputTransition: PreCommitted{
 				block.SignedPreCommit{
 					PreCommit: block.PreCommit{
-						block.Polka{
+						Polka: block.Polka{
 							Block: &genesis,
 						},
 					},
@@ -544,7 +544,7 @@ func generateTestCases() []TestCase {
 			inputTransition: PreCommitted{
 				block.SignedPreCommit{
 					PreCommit: block.PreCommit{
-						block.Polka{
+						Polka: block.Polka{
 							Block:  nil,
 							Height: 1,
 							Round:  1,
@@ -577,7 +577,7 @@ func generateTestCases() []TestCase {
 			inputTransition: PreCommitted{
 				block.SignedPreCommit{
 					PreCommit: block.PreCommit{
-						block.Polka{
+						Polka: block.Polka{
 							Block:  nil,
 							Height: 1,
 							Round:  1,

--- a/consensus/state_machine_test.go
+++ b/consensus/state_machine_test.go
@@ -1,1 +1,654 @@
 package consensus_test
+
+import (
+	"crypto/rand"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/renproject/hyperdrive/block"
+	"github.com/renproject/hyperdrive/sig"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/renproject/hyperdrive/consensus"
+)
+
+var _ = Describe("State Machine", func() {
+
+	polkaBuilder := make(map[block.Height]map[sig.Signatory]block.SignedPreVote)
+	stateMachine := NewStateMachine(polkaBuilder, block.CommitBuilder{}, 2)
+
+	testCases := generateTestCases()
+
+	for _, t := range testCases {
+		t := t
+
+		Context(fmt.Sprintf("when the state machine gets (%s, %s)", reflect.TypeOf(t.inputState).Name(), reflect.TypeOf(t.inputTransition).Name()), func() {
+			It(fmt.Sprintf("should return (%s, %s)", t.expectedState, t.expectedAction), func() {
+				state, action := stateMachine.Transition(t.inputState, t.inputTransition)
+				t.validateResults(state, action)
+			})
+		})
+	}
+})
+
+type TestCase struct {
+	inputState      State
+	inputTransition Transition
+
+	expectedState   string
+	expectedAction  string
+	validateResults func(state State, action Action)
+}
+
+func generateTestCases() []TestCase {
+	genesis := block.Genesis()
+
+	return []TestCase{
+
+		// Invalid state
+		{
+			inputState: InvalidState{height: 0, round: 0},
+			inputTransition: PreVoted{
+				block.SignedPreVote{
+					PreVote: block.PreVote{
+						Block: &block.Block{
+							Height: 0,
+							Round:  0,
+						},
+					},
+				},
+			},
+
+			expectedState:  "nil",
+			expectedAction: "nil",
+			validateResults: func(state State, action Action) {
+				Expect(state).To(BeNil())
+				Expect(action).To(BeNil())
+			},
+		},
+
+		// Invalid transition
+		{
+			inputState:      WaitForPropose(0, 0),
+			inputTransition: InvalidTransition{},
+
+			expectedState:  "WaitingForPropose",
+			expectedAction: "nil",
+			validateResults: func(state State, action Action) {
+				_, ok := state.(WaitingForPropose)
+				Expect(ok).To(Equal(true), "state should have been WaitingForPolka")
+				Expect(action).To(BeNil())
+			},
+		},
+
+		// (WaitForPropose, TimedOut)
+		{
+			inputState:      WaitForPropose(0, 0),
+			inputTransition: TimedOut{},
+
+			expectedState:  "WaitingForPolka",
+			expectedAction: "PreVote",
+			validateResults: func(state State, action Action) {
+				_, ok := state.(WaitingForPolka)
+				Expect(ok).To(Equal(true), "state should have been WaitingForPolka")
+				prevote, ok := action.(PreVote)
+				Expect(ok).To(Equal(true), "action should have been PreVote")
+				Expect(prevote.PreVote.Round).To(Equal(genesis.Round))
+				Expect(prevote.PreVote.Height).To(Equal(genesis.Height))
+				Expect(prevote.PreVote.Block).To(BeNil())
+			},
+		},
+
+		// (WaitForPropose, Proposed)
+		{
+			inputState:      WaitForPropose(0, 0),
+			inputTransition: Proposed{block.Block{}},
+
+			expectedState:  "WaitingForPolka",
+			expectedAction: "PreVote",
+			validateResults: func(state State, action Action) {
+				_, ok := state.(WaitingForPolka)
+				Expect(ok).To(Equal(true), "state should have been WaitingForPolka")
+				prevote, ok := action.(PreVote)
+				Expect(ok).To(Equal(true), "action should have been PreVote")
+				Expect(prevote.PreVote.Round).To(Equal(genesis.Round))
+				Expect(prevote.PreVote.Height).To(Equal(genesis.Height))
+				verifyBlock(prevote.PreVote.Block, &genesis)
+			},
+		},
+
+		// (WaitForPropose, PreVoted)
+		{
+			inputState: WaitForPropose(0, 0),
+			inputTransition: PreVoted{
+				block.SignedPreVote{
+					PreVote: block.PreVote{
+						Block: &genesis,
+					},
+					Signatory: randomSignatory(),
+					Signature: randomSignature(),
+				},
+			},
+
+			expectedState:  "WaitingForPolka",
+			expectedAction: "PreVote",
+			validateResults: func(state State, action Action) {
+				_, ok := state.(WaitingForPolka)
+				Expect(ok).To(Equal(true), "state should have been WaitingForPolka")
+				prevote, ok := action.(PreVote)
+				Expect(ok).To(Equal(true), "action should have been PreVote")
+				Expect(prevote.PreVote.Round).To(Equal(genesis.Round))
+				Expect(prevote.PreVote.Height).To(Equal(genesis.Height))
+				verifyBlock(prevote.PreVote.Block, &genesis)
+			},
+		},
+
+		// (WaitForPropose, PreVoted)
+		{
+			inputState: WaitForPropose(0, 0),
+			inputTransition: PreVoted{
+				block.SignedPreVote{
+					PreVote: block.PreVote{
+						Block: &genesis,
+					},
+					Signatory: randomSignatory(),
+					Signature: randomSignature(),
+				},
+			},
+
+			expectedState:  "WaitingForCommit",
+			expectedAction: "PreCommit",
+			validateResults: func(state State, action Action) {
+				_, ok := state.(WaitingForCommit)
+				fmt.Println(reflect.TypeOf(state).Name())
+				Expect(ok).To(Equal(true), "state should have been WaitingForCommit")
+				precommit, ok := action.(PreCommit)
+				Expect(ok).To(Equal(true), "action should have been PreCommit")
+				Expect(precommit.PreCommit.Polka.Round).To(Equal(genesis.Round))
+				Expect(precommit.PreCommit.Polka.Height).To(Equal(genesis.Height))
+				verifyBlock(precommit.PreCommit.Polka.Block, &genesis)
+			},
+		},
+
+		// (WaitForPropose, PreCommitted)
+		{
+			inputState: WaitForPropose(0, 0),
+			inputTransition: PreCommitted{
+				block.SignedPreCommit{
+					PreCommit: block.PreCommit{
+						block.Polka{
+							Block: &genesis,
+						},
+					},
+					Signatory: randomSignatory(),
+					Signature: randomSignature(),
+				},
+			},
+
+			expectedState:  "WaitingForCommit",
+			expectedAction: "PreCommit",
+			validateResults: func(state State, action Action) {
+				_, ok := state.(WaitingForCommit)
+				Expect(ok).To(Equal(true), "state should have been WaitingForCommit")
+				precommit, ok := action.(PreCommit)
+				Expect(ok).To(Equal(true), "action should have been PreCommit")
+				Expect(precommit.PreCommit.Polka.Round).To(Equal(genesis.Round))
+				Expect(precommit.PreCommit.Polka.Height).To(Equal(genesis.Height))
+				verifyBlock(precommit.PreCommit.Polka.Block, &genesis)
+			},
+		},
+
+		// (WaitForPropose, PreCommitted)
+		{
+			inputState: WaitForPropose(0, 0),
+			inputTransition: PreCommitted{
+				block.SignedPreCommit{
+					PreCommit: block.PreCommit{
+						block.Polka{
+							Block: &genesis,
+						},
+					},
+					Signatory: randomSignatory(),
+					Signature: randomSignature(),
+				},
+			},
+
+			expectedState:  "WaitingForPropose",
+			expectedAction: "Commit",
+			validateResults: func(state State, action Action) {
+				_, ok := state.(WaitingForPropose)
+				Expect(ok).To(Equal(true), "state should have been WaitingForPropose")
+				commit, ok := action.(Commit)
+				Expect(ok).To(Equal(true), "action should have been Commit")
+				Expect(commit.Commit.Polka.Round).To(Equal(genesis.Round))
+				Expect(commit.Commit.Polka.Height).To(Equal(genesis.Height))
+				verifyBlock(commit.Commit.Polka.Block, &genesis)
+			},
+		},
+
+		// (WaitForPropose, Proposed) state.Round != block.Round
+		{
+			inputState:      WaitForPropose(1, 0),
+			inputTransition: Proposed{block.Block{}},
+
+			expectedState:  "WaitingForPropose",
+			expectedAction: "nil",
+			validateResults: func(state State, action Action) {
+				_, ok := state.(WaitingForPropose)
+				Expect(ok).To(Equal(true), "state should have been WaitingForPropose")
+				Expect(action).To(BeNil())
+			},
+		},
+
+		// (WaitForPropose, Proposed) state.Height != block.Height
+		{
+			inputState:      WaitForPropose(0, 1),
+			inputTransition: Proposed{block.Block{}},
+
+			expectedState:  "WaitingForPropose",
+			expectedAction: "nil",
+			validateResults: func(state State, action Action) {
+				_, ok := state.(WaitingForPropose)
+				Expect(ok).To(Equal(true), "state should have been WaitingForPropose")
+				Expect(action).To(BeNil())
+			},
+		},
+
+		// (WaitForPropose, Proposed) block.Time > time.Now()
+		{
+			inputState: WaitForPropose(0, 0),
+			inputTransition: Proposed{block.Block{
+				Time: time.Now().Add(10 * time.Minute),
+			}},
+
+			expectedState:  "WaitingForPropose",
+			expectedAction: "nil",
+			validateResults: func(state State, action Action) {
+				_, ok := state.(WaitingForPropose)
+				Expect(ok).To(Equal(true), "state should have been WaitingForPropose")
+				Expect(action).To(BeNil())
+			},
+		},
+
+		// (WaitForPropose, Prevoted) state.Round != block.Round
+		{
+			inputState: WaitForPropose(0, 0),
+			inputTransition: PreVoted{
+				block.SignedPreVote{
+					PreVote: block.PreVote{
+						Block: &block.Block{
+							Height: 0,
+							Round:  1,
+						},
+						Round:  1,
+						Height: 0,
+					},
+				},
+			},
+
+			expectedState:  "WaitingForPropose",
+			expectedAction: "nil",
+			validateResults: func(state State, action Action) {
+				_, ok := state.(WaitingForPropose)
+				Expect(ok).To(Equal(true), "state should have been WaitingForPropose")
+				Expect(action).To(BeNil())
+			},
+		},
+
+		// (WaitForPropose, Prevoted) state.Height != block.Height
+		{
+			inputState: WaitForPropose(0, 0),
+			inputTransition: PreVoted{
+				block.SignedPreVote{
+					PreVote: block.PreVote{
+						Block: &block.Block{
+							Height: 1,
+							Round:  0,
+						},
+						Round:  0,
+						Height: 1,
+					},
+				},
+			},
+
+			expectedState:  "WaitingForPropose",
+			expectedAction: "nil",
+			validateResults: func(state State, action Action) {
+				_, ok := state.(WaitingForPropose)
+				Expect(ok).To(Equal(true), "state should have been WaitingForPropose")
+				Expect(action).To(BeNil())
+			},
+		},
+
+		// (WaitForPropose, PreCommitted) state.Round != block.Round
+		{
+			inputState: WaitForPropose(0, 0),
+			inputTransition: PreCommitted{
+				block.SignedPreCommit{
+					PreCommit: block.PreCommit{
+						block.Polka{
+							Block: &block.Block{
+								Height: 0,
+								Round:  0,
+							},
+							Height: 0,
+							Round:  1,
+						},
+					},
+				},
+			},
+
+			expectedState:  "WaitingForPropose",
+			expectedAction: "nil",
+			validateResults: func(state State, action Action) {
+				_, ok := state.(WaitingForPropose)
+				Expect(ok).To(Equal(true), "state should have been WaitingForPropose")
+				Expect(action).To(BeNil())
+			},
+		},
+
+		// (WaitForPropose, PreCommitted) state.Height != block.Height
+		{
+			inputState: WaitForPropose(0, 0),
+			inputTransition: PreCommitted{
+				block.SignedPreCommit{
+					PreCommit: block.PreCommit{
+						block.Polka{
+							Block: &block.Block{
+								Height: 0,
+								Round:  0,
+							},
+							Height: 1,
+							Round:  0,
+						},
+					},
+					Signatory: randomSignatory(),
+					Signature: randomSignature(),
+				},
+			},
+
+			expectedState:  "WaitingForPropose",
+			expectedAction: "nil",
+			validateResults: func(state State, action Action) {
+				_, ok := state.(WaitingForPropose)
+				Expect(ok).To(Equal(true), "state should have been WaitingForPropose")
+				Expect(action).To(BeNil())
+			},
+		},
+
+		// (WaitForPolka, Proposed)
+		{
+			inputState:      WaitForPolka(0, 0),
+			inputTransition: Proposed{block.Block{}},
+
+			expectedState:  "WaitingForPolka",
+			expectedAction: "nil",
+			validateResults: func(state State, action Action) {
+				_, ok := state.(WaitingForPolka)
+				Expect(ok).To(Equal(true), "state should have been WaitingForPolka")
+				Expect(action).To(BeNil())
+			},
+		},
+
+		// (WaitForPolka, PreVoted)
+		{
+			inputState: WaitForPolka(0, 0),
+			inputTransition: PreVoted{
+				block.SignedPreVote{
+					PreVote: block.PreVote{
+						Block: &block.Block{
+							Height: 0,
+							Round:  0,
+						},
+					},
+					Signatory: randomSignatory(),
+					Signature: randomSignature(),
+				},
+			},
+
+			expectedState:  "WaitingForCommit",
+			expectedAction: "PreCommit",
+			validateResults: func(state State, action Action) {
+				_, ok := state.(WaitingForCommit)
+				Expect(ok).To(Equal(true), "state should have been WaitingForCommit")
+				precommit, ok := action.(PreCommit)
+				Expect(ok).To(Equal(true), "action should have been PreCommit")
+				Expect(precommit.PreCommit.Polka.Round).To(Equal(genesis.Round))
+				Expect(precommit.PreCommit.Polka.Height).To(Equal(genesis.Height))
+				verifyBlock(precommit.PreCommit.Polka.Block, &genesis)
+			},
+		},
+
+		// (WaitForPolka, PreCommitted)
+		{
+			inputState: WaitForPolka(0, 0),
+			inputTransition: PreCommitted{
+				block.SignedPreCommit{
+					PreCommit: block.PreCommit{
+						block.Polka{
+							Block: &block.Block{
+								Height: 0,
+								Round:  0,
+							},
+						},
+					},
+					Signatory: randomSignatory(),
+					Signature: randomSignature(),
+				},
+			},
+
+			expectedState:  "WaitingForPropose",
+			expectedAction: "Commit",
+			validateResults: func(state State, action Action) {
+				_, ok := state.(WaitingForPropose)
+				Expect(ok).To(Equal(true), "state should have been WaitingForPropose")
+				commit, ok := action.(Commit)
+				Expect(ok).To(Equal(true), "action should have been Commit")
+				Expect(commit.Commit.Polka.Round).To(Equal(genesis.Round))
+				Expect(commit.Commit.Polka.Height).To(Equal(genesis.Height))
+				verifyBlock(commit.Commit.Polka.Block, &genesis)
+			},
+		},
+
+		// (WaitForCommit, Proposed)
+		{
+			inputState: WaitForCommit(block.Polka{
+				Block: &block.Block{
+					Height: 0,
+					Round:  0,
+				},
+			}),
+			inputTransition: Proposed{
+				block.Block{
+					Height: 0,
+					Round:  0,
+				}},
+
+			expectedState:  "WaitingForCommit",
+			expectedAction: "nil",
+			validateResults: func(state State, action Action) {
+				_, ok := state.(WaitingForCommit)
+				Expect(ok).To(Equal(true), "state should have been WaitingForCommit")
+				Expect(action).To(BeNil())
+			},
+		},
+
+		// (WaitForCommit, PreVoted)
+		{
+			inputState: WaitForCommit(block.Polka{
+				Block: &block.Block{
+					Height: 0,
+					Round:  0,
+				},
+			}),
+			inputTransition: PreVoted{
+				block.SignedPreVote{
+					PreVote: block.PreVote{
+						Block: &block.Block{
+							Height: 0,
+							Round:  0,
+						},
+					},
+					Signatory: randomSignatory(),
+					Signature: randomSignature(),
+				},
+			},
+
+			expectedState:  "WaitingForCommit",
+			expectedAction: "nil",
+			validateResults: func(state State, action Action) {
+				_, ok := state.(WaitingForCommit)
+				Expect(ok).To(Equal(true), "state should have been WaitingForCommit")
+				Expect(action).To(BeNil())
+			},
+		},
+
+		// (WaitForCommit, PreCommitted)
+		{
+			inputState: WaitForCommit(block.Polka{
+				Block: &genesis,
+			}),
+			inputTransition: PreCommitted{
+				block.SignedPreCommit{
+					PreCommit: block.PreCommit{
+						block.Polka{
+							Block: &genesis,
+						},
+					},
+					Signatory: randomSignatory(),
+					Signature: randomSignature(),
+				},
+			},
+
+			expectedState:  "WaitingForPropose",
+			expectedAction: "Commit",
+			validateResults: func(state State, action Action) {
+				_, ok := state.(WaitingForPropose)
+				Expect(ok).To(Equal(true), "state should have been WaitingForPropose")
+				commit, ok := action.(Commit)
+				Expect(ok).To(Equal(true), "action should have been Commit")
+				Expect(commit.Commit.Polka.Round).To(Equal(genesis.Round))
+				Expect(commit.Commit.Polka.Height).To(Equal(genesis.Height))
+				verifyBlock(commit.Commit.Polka.Block, &genesis)
+			},
+		},
+
+		// (WaitForCommit, PreCommitted)
+		{
+			inputState: WaitForCommit(block.Polka{
+				Block:  nil,
+				Height: 1,
+				Round:  1,
+			}),
+			inputTransition: PreCommitted{
+				block.SignedPreCommit{
+					PreCommit: block.PreCommit{
+						block.Polka{
+							Block:  nil,
+							Height: 1,
+							Round:  1,
+						},
+					},
+					Signatory: randomSignatory(),
+					Signature: randomSignature(),
+				},
+			},
+
+			expectedState:  "WaitingForPropose",
+			expectedAction: "Commit",
+			validateResults: func(state State, action Action) {
+				_, ok := state.(WaitingForPropose)
+				Expect(ok).To(Equal(true), "state should have been WaitingForPropose")
+				commit, ok := action.(Commit)
+				Expect(ok).To(Equal(true), "action should have been Commit")
+				Expect(commit.Commit.Polka.Round).NotTo(Equal(1))
+				Expect(commit.Commit.Polka.Height).NotTo(Equal(1))
+			},
+		},
+
+		// (WaitForCommit, PreCommitted)
+		{
+			inputState: WaitForCommit(block.Polka{
+				Block:  nil,
+				Height: 1,
+				Round:  1,
+			}),
+			inputTransition: PreCommitted{
+				block.SignedPreCommit{
+					PreCommit: block.PreCommit{
+						block.Polka{
+							Block:  nil,
+							Height: 1,
+							Round:  1,
+						},
+					},
+					Signatory: randomSignatory(),
+					Signature: randomSignature(),
+				},
+			},
+
+			expectedState:  "WaitingForPropose",
+			expectedAction: "Commit",
+			validateResults: func(state State, action Action) {
+				_, ok := state.(WaitingForPropose)
+				Expect(ok).To(Equal(true), "state should have been WaitingForPropose")
+				Expect(action).To(BeNil())
+			},
+		},
+	}
+}
+
+func verifyBlock(res *block.Block, expected *block.Block) {
+	Expect(res.Round).To(Equal(expected.Round))
+	Expect(res.Height).To(Equal(expected.Height))
+	Expect(res.Header).To(Equal(expected.Header))
+	Expect(res.ParentHeader).To(Equal(expected.ParentHeader))
+	Expect(res.Signature).To(Equal(expected.Signature))
+	Expect(res.Signatory).To(Equal(expected.Signatory))
+}
+
+type InvalidState struct {
+	round  block.Round
+	height block.Height
+}
+
+func (state InvalidState) Round() block.Round {
+	return state.round
+}
+
+func (state InvalidState) Height() block.Height {
+	return state.height
+}
+
+type InvalidTransition struct {
+}
+
+func (transition InvalidTransition) IsTransition() {}
+
+func randomSignatory() sig.Signatory {
+	key := make([]byte, 20)
+	_, err := rand.Read(key)
+	if err != nil {
+		panic(err)
+	}
+
+	signatory := sig.Signatory{}
+	copy(signatory[:], key[:])
+
+	return signatory
+}
+
+func randomSignature() sig.Signature {
+	key := make([]byte, 65)
+	_, err := rand.Read(key)
+	if err != nil {
+		panic(err)
+	}
+
+	sign := sig.Signature{}
+	copy(sign[:], key[:])
+
+	return sign
+}

--- a/consensus/transition.go
+++ b/consensus/transition.go
@@ -53,6 +53,7 @@ type Transition interface {
 }
 
 // TimedOut waiting for some other external event.
+// FIXME: TimedOut should probably have Height and Round
 type TimedOut struct {
 	time.Time
 }

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,7 @@ github.com/gliderlabs/ssh v0.1.3/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aev
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
+github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -1,14 +1,14 @@
-// Package replica core package
-//
-// I assume that all provided `Transition`s are well formed and valid by
-// the time they reach this module.
 package replica
 
 import (
+	"log"
+	"time"
+
 	"github.com/renproject/hyperdrive/block"
 	"github.com/renproject/hyperdrive/consensus"
 	"github.com/renproject/hyperdrive/shard"
 	"github.com/renproject/hyperdrive/sig"
+	"github.com/renproject/hyperdrive/sig/ecdsa"
 	"github.com/renproject/hyperdrive/tx"
 )
 
@@ -131,19 +131,19 @@ func (replica *replica) shouldDropTransition(transition consensus.Transition) bo
 func (replica *replica) shouldBufferTransition(transition consensus.Transition) bool {
 	switch transition := transition.(type) {
 	case consensus.Proposed:
-		if transition.Height > replica.state.Height() {
-			return true
+		if transition.Height <= replica.state.Height() {
+			return false
 		}
 	case consensus.PreVoted:
-		if transition.Height > replica.state.Height() {
-			return true
+		if transition.Height <= replica.state.Height() {
+			return false
 		}
 	case consensus.PreCommitted:
-		if transition.Polka.Height > replica.state.Height() {
-			return true
+		if transition.Polka.Height <= replica.state.Height() {
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 func (replica *replica) shouldProposeBlock() bool {
@@ -152,5 +152,33 @@ func (replica *replica) shouldProposeBlock() bool {
 
 func (replica *replica) generateBlock() block.Block {
 	// TODO: Generate a Block using the transaction Pool, current Blockchain, and current Shard.
-	return block.Block{}
+	transaction, ok := replica.txPool.Dequeue()
+	if !ok {
+		return block.Block{}
+	}
+
+	parent, ok := replica.blockchain.Head()
+	if !ok {
+		parent = block.Genesis()
+	}
+
+	newBlock := block.Block{
+		Time:         time.Now(),
+		Round:        replica.blockchain.Round() + 1,
+		Height:       replica.blockchain.Height() + 1,
+		Header:       replica.shard.Hash,
+		ParentHeader: parent.Header,
+		Signatory:    replica.signer.Signatory(),
+		Txs:          []tx.Transaction{transaction}, // TODO: get all pending txs in the pool
+	}
+
+	var err error
+	// TODO: (review) Sign the entire block?
+	newBlock.Signature, err = replica.signer.Sign(ecdsa.Hash([]byte(newBlock.String())))
+	if err != nil {
+		log.Println(err)
+		return block.Block{}
+	}
+	return newBlock
+
 }

--- a/replica/replica_test.go
+++ b/replica/replica_test.go
@@ -25,7 +25,12 @@ var _ = Describe("Replica", func() {
 		stateMachine := consensus.NewStateMachine(block.PolkaBuilder{}, block.CommitBuilder{}, 1)
 		transitionBuffer = newMockTransitionBuffer()
 
-		shard := shard.Shard{sig.Hash{}, sig.Hash{}, 0, sig.Signatories{signer.Signatory()}}
+		shard := shard.Shard{
+			Hash:        sig.Hash{},
+			BlockHeader: sig.Hash{},
+			BlockHeight: 0,
+			Signatories: sig.Signatories{signer.Signatory()},
+		}
 
 		pool = NewMockLifoPool()
 
@@ -79,7 +84,7 @@ func generateTestCases() []TestCase {
 		// Proposed with invalid Height
 		{
 			inputTransition: consensus.Proposed{
-				block.Block{
+				Block: block.Block{
 					Height: -1,
 				}},
 
@@ -91,7 +96,7 @@ func generateTestCases() []TestCase {
 		// PreVoted with invalid Height
 		{
 			inputTransition: consensus.PreVoted{
-				block.SignedPreVote{
+				SignedPreVote: block.SignedPreVote{
 					PreVote: block.PreVote{
 						Height: -1,
 					},
@@ -106,9 +111,9 @@ func generateTestCases() []TestCase {
 		// PreCommitted with invalid Height
 		{
 			inputTransition: consensus.PreCommitted{
-				block.SignedPreCommit{
+				SignedPreCommit: block.SignedPreCommit{
 					PreCommit: block.PreCommit{
-						block.Polka{
+						Polka: block.Polka{
 							Block:  &block.Block{},
 							Height: -1,
 						},
@@ -124,7 +129,7 @@ func generateTestCases() []TestCase {
 		// Proposed from the future
 		{
 			inputTransition: consensus.Proposed{
-				block.Block{
+				Block: block.Block{
 					Height: 1,
 				}},
 
@@ -136,7 +141,7 @@ func generateTestCases() []TestCase {
 		// PreVoted from the future
 		{
 			inputTransition: consensus.PreVoted{
-				block.SignedPreVote{
+				SignedPreVote: block.SignedPreVote{
 					PreVote: block.PreVote{
 						Height: 1,
 					},
@@ -151,9 +156,9 @@ func generateTestCases() []TestCase {
 		// PreCommitted from the future
 		{
 			inputTransition: consensus.PreCommitted{
-				block.SignedPreCommit{
+				SignedPreCommit: block.SignedPreCommit{
 					PreCommit: block.PreCommit{
-						block.Polka{
+						Polka: block.Polka{
 							Block:  &block.Block{},
 							Height: 1,
 						},
@@ -169,7 +174,7 @@ func generateTestCases() []TestCase {
 		// Proposed for the current Height
 		{
 			inputTransition: consensus.Proposed{
-				block.Block{
+				Block: block.Block{
 					Height: 0,
 				}},
 
@@ -181,7 +186,7 @@ func generateTestCases() []TestCase {
 		// PreVoted for the current height
 		{
 			inputTransition: consensus.PreVoted{
-				block.SignedPreVote{
+				SignedPreVote: block.SignedPreVote{
 					PreVote: block.PreVote{
 						Height: 0,
 					},
@@ -196,9 +201,9 @@ func generateTestCases() []TestCase {
 		// PreCommitted for the current height
 		{
 			inputTransition: consensus.PreCommitted{
-				block.SignedPreCommit{
+				SignedPreCommit: block.SignedPreCommit{
 					PreCommit: block.PreCommit{
-						block.Polka{
+						Polka: block.Polka{
 							Block:  &block.Block{},
 							Height: 0,
 						},

--- a/replica/replica_test.go
+++ b/replica/replica_test.go
@@ -1,11 +1,307 @@
 package replica_test
 
-// import (
-// 	. "github.com/onsi/ginkgo"
-// 	. "github.com/onsi/gomega"
-// 	. "github.com/renproject/hyperdrive/replica"
-// )
+import (
+	"fmt"
+	"reflect"
+	"sync"
 
-// var _ = Describe("Replica", func() {
+	"github.com/renproject/hyperdrive/block"
+	"github.com/renproject/hyperdrive/consensus"
+	"github.com/renproject/hyperdrive/shard"
+	"github.com/renproject/hyperdrive/sig"
+	"github.com/renproject/hyperdrive/sig/ecdsa"
+	"github.com/renproject/hyperdrive/tx"
 
-// })
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/renproject/hyperdrive/replica"
+)
+
+var _ = Describe("Replica", func() {
+
+	BeforeSuite(func() {
+		signer, err := ecdsa.NewFromRandom()
+		Expect(err).ShouldNot(HaveOccurred())
+		stateMachine := consensus.NewStateMachine(block.PolkaBuilder{}, block.CommitBuilder{}, 1)
+		transitionBuffer = newMockTransitionBuffer()
+
+		shard := shard.Shard{sig.Hash{}, sig.Hash{}, 0, sig.Signatories{signer.Signatory()}}
+
+		pool = NewMockLifoPool()
+
+		dispatcher = newMockDispatcher()
+		replica = New(dispatcher, signer, pool, consensus.WaitForPropose(0, 0), stateMachine, transitionBuffer, block.NewBlockchain(), shard)
+
+	})
+
+	Context("when a new Transaction is sent using Transact", func() {
+
+		It("should update the TxPool", func() {
+			replica.Transact(tx.Transaction{})
+			Expect(pool.Length()).Should(Equal(1))
+		})
+
+	})
+
+	Context("when new Transitions are sent", func() {
+
+		testCases := generateTestCases()
+		for _, t := range testCases {
+			t := t
+
+			Context(fmt.Sprintf("when the replica gets transition - %s", reflect.TypeOf(t.inputTransition).Name()), func() {
+				It("should ", func() {
+
+					replica.Transition(t.inputTransition)
+					t.validateResults()
+				})
+			})
+		}
+
+	})
+})
+
+type TestCase struct {
+	inputTransition consensus.Transition
+
+	validateResults func()
+}
+
+var replica Replica
+var dispatcher *mockDispatcher
+var transitionBuffer *mockTransitionBuffer
+var pool *mockLifoPool
+
+func generateTestCases() []TestCase {
+
+	return []TestCase{
+
+		// Proposed with invalid Height
+		{
+			inputTransition: consensus.Proposed{
+				block.Block{
+					Height: -1,
+				}},
+
+			validateResults: func() {
+				Expect(dispatcher.BufferLength()).Should(Equal(0))
+			},
+		},
+
+		// PreVoted with invalid Height
+		{
+			inputTransition: consensus.PreVoted{
+				block.SignedPreVote{
+					PreVote: block.PreVote{
+						Height: -1,
+					},
+				},
+			},
+
+			validateResults: func() {
+				Expect(dispatcher.BufferLength()).Should(Equal(0))
+			},
+		},
+
+		// PreCommitted with invalid Height
+		{
+			inputTransition: consensus.PreCommitted{
+				block.SignedPreCommit{
+					PreCommit: block.PreCommit{
+						block.Polka{
+							Block:  &block.Block{},
+							Height: -1,
+						},
+					},
+				},
+			},
+
+			validateResults: func() {
+				Expect(dispatcher.BufferLength()).Should(Equal(0))
+			},
+		},
+
+		// Proposed from the future
+		{
+			inputTransition: consensus.Proposed{
+				block.Block{
+					Height: 1,
+				}},
+
+			validateResults: func() {
+				Expect(transitionBuffer.BufferLength()).Should(Equal(1))
+			},
+		},
+
+		// PreVoted from the future
+		{
+			inputTransition: consensus.PreVoted{
+				block.SignedPreVote{
+					PreVote: block.PreVote{
+						Height: 1,
+					},
+				},
+			},
+
+			validateResults: func() {
+				Expect(transitionBuffer.BufferLength()).Should(Equal(2))
+			},
+		},
+
+		// PreCommitted from the future
+		{
+			inputTransition: consensus.PreCommitted{
+				block.SignedPreCommit{
+					PreCommit: block.PreCommit{
+						block.Polka{
+							Block:  &block.Block{},
+							Height: 1,
+						},
+					},
+				},
+			},
+
+			validateResults: func() {
+				Expect(transitionBuffer.BufferLength()).Should(Equal(3))
+			},
+		},
+
+		// Proposed for the current Height
+		{
+			inputTransition: consensus.Proposed{
+				block.Block{
+					Height: 0,
+				}},
+
+			validateResults: func() {
+				Expect(dispatcher.BufferLength()).Should(Equal(1))
+			},
+		},
+
+		// PreVoted for the current height
+		{
+			inputTransition: consensus.PreVoted{
+				block.SignedPreVote{
+					PreVote: block.PreVote{
+						Height: 0,
+					},
+				},
+			},
+
+			validateResults: func() {
+				Expect(dispatcher.BufferLength()).Should(Equal(2))
+			},
+		},
+
+		// PreCommitted for the current height
+		{
+			inputTransition: consensus.PreCommitted{
+				block.SignedPreCommit{
+					PreCommit: block.PreCommit{
+						block.Polka{
+							Block:  &block.Block{},
+							Height: 0,
+						},
+					},
+				},
+			},
+
+			validateResults: func() {
+				Expect(dispatcher.BufferLength()).Should(Equal(4))
+			},
+		},
+	}
+}
+
+type mockDispatcher struct {
+	actionsMu *sync.Mutex
+	actions   []consensus.Action
+}
+
+func newMockDispatcher() *mockDispatcher {
+	return &mockDispatcher{
+		new(sync.Mutex),
+		[]consensus.Action{},
+	}
+}
+
+func (mockDispatcher *mockDispatcher) Dispatch(action consensus.Action) {
+	mockDispatcher.actionsMu.Lock()
+	defer mockDispatcher.actionsMu.Unlock()
+
+	mockDispatcher.actions = append(mockDispatcher.actions, action)
+}
+
+func (mockDispatcher *mockDispatcher) BufferLength() int {
+	mockDispatcher.actionsMu.Lock()
+	defer mockDispatcher.actionsMu.Unlock()
+
+	return len(mockDispatcher.actions)
+}
+
+type mockTransitionBuffer struct {
+	transitionsMu *sync.Mutex
+	transitions   []consensus.Transition
+}
+
+func newMockTransitionBuffer() *mockTransitionBuffer {
+	return &mockTransitionBuffer{
+		new(sync.Mutex),
+		[]consensus.Transition{},
+	}
+}
+
+func (mockTransitionBuffer *mockTransitionBuffer) Enqueue(transition consensus.Transition) {
+	mockTransitionBuffer.transitionsMu.Lock()
+	defer mockTransitionBuffer.transitionsMu.Unlock()
+
+	mockTransitionBuffer.transitions = append(mockTransitionBuffer.transitions, transition)
+}
+
+func (mockTransitionBuffer *mockTransitionBuffer) Dequeue(h block.Height) (consensus.Transition, bool) {
+	mockTransitionBuffer.transitionsMu.Lock()
+	defer mockTransitionBuffer.transitionsMu.Unlock()
+
+	if len(mockTransitionBuffer.transitions) > 0 {
+		tx := mockTransitionBuffer.transitions[len(mockTransitionBuffer.transitions)-1]
+		mockTransitionBuffer.transitions = mockTransitionBuffer.transitions[:len(mockTransitionBuffer.transitions)-1]
+		return tx, true
+	}
+	return nil, false
+}
+
+func (mockTransitionBuffer *mockTransitionBuffer) Drop(height block.Height) {
+
+}
+
+func (mockTransitionBuffer *mockTransitionBuffer) BufferLength() int {
+	mockTransitionBuffer.transitionsMu.Lock()
+	defer mockTransitionBuffer.transitionsMu.Unlock()
+
+	return len(mockTransitionBuffer.transitions)
+}
+
+type mockLifoPool struct {
+	txs []tx.Transaction
+}
+
+func NewMockLifoPool() *mockLifoPool {
+	return &mockLifoPool{[]tx.Transaction{}}
+}
+
+func (pool *mockLifoPool) Enqueue(tx tx.Transaction) {
+	pool.txs = append(pool.txs, tx)
+}
+
+func (pool *mockLifoPool) Dequeue() (tx.Transaction, bool) {
+	if len(pool.txs) > 0 {
+		tx := pool.txs[len(pool.txs)-1]
+		pool.txs = pool.txs[:len(pool.txs)-1]
+		return tx, true
+	}
+	return tx.Transaction{}, false
+}
+
+func (pool *mockLifoPool) Length() int {
+	return len(pool.txs)
+}

--- a/tx/tx.go
+++ b/tx/tx.go
@@ -1,6 +1,7 @@
 package tx
 
 type Transaction struct {
+	Data [32]byte
 }
 
 type Transactions []Transaction


### PR DESCRIPTION
This PR adds tests for `state_machine.go` and `replica.go` along with minor fixes (primarily when blocks are `nil`) in `block` and `consensus` package. 