### PR TITLE
Update block validation interface to provide additional context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
             go get -u golang.org/x/crypto/...
             go get -u github.com/loongy/covermerge
             go get -u github.com/mattn/goveralls
+            go get -u golang.org/x/lint/golint
             CI=true /go/bin/ginkgo -v --race --cover --coverprofile coverprofile.out ./...
             /go/bin/covermerge            \
               block/coverprofile.out      \

--- a/process/process.go
+++ b/process/process.go
@@ -279,7 +279,7 @@ func (p *Process) handlePropose(propose *Propose) {
 						p.state.CurrentRound,
 						block.InvalidHash,
 					)
-					p.logger.Infof("prevoted=<nil> at height=%v and round=%v (invalid proposal, err = %v)", propose.height, propose.round, err)
+					p.logger.Warnf("prevoted=<nil> at height=%v and round=%v (invalid propose: %v)", propose.height, propose.round, err)
 				}
 				p.state.CurrentStep = StepPrevote
 				p.broadcaster.Broadcast(prevote)
@@ -451,7 +451,7 @@ func (p *Process) checkProposeInCurrentHeightAndRoundWithPrevotes() {
 						p.state.CurrentRound,
 						block.InvalidHash,
 					)
-					p.logger.Infof("prevoted=<nil> at height=%v and round=%v (invalid proposal, err = %v)", prevote.height, prevote.round, err)
+					p.logger.Warnf("prevoted=<nil> at height=%v and round=%v (invalid propose: %v)", prevote.height, prevote.round, err)
 				}
 
 				p.state.CurrentStep = StepPrevote
@@ -495,7 +495,7 @@ func (p *Process) checkProposeInCurrentHeightAndRoundWithPrevotesForTheFirstTime
 				p.broadcaster.Broadcast(precommit)
 			}
 		} else {
-			p.logger.Infof("failed to precommit at height=%v, round=%v and step=%v (invalid block, err = %v)", propose.height, propose.round, p.state.CurrentStep, err)
+			p.logger.Warnf("nothing precommitted at height=%v, round=%v and step=%v (invalid block: %v)", propose.height, propose.round, p.state.CurrentStep, err)
 		}
 	}
 }
@@ -524,7 +524,7 @@ func (p *Process) checkProposeInCurrentHeightWithPrecommits(round block.Round) {
 				p.logger.Infof("✅ committed block=%v at height=%v", propose.BlockHash(), propose.height)
 				p.startRound(0)
 			} else {
-				p.logger.Infof("failed to commit at height=%v and round=%v (invalid block, err = %v)", propose.height, propose.round, err)
+				p.logger.Warnf("nothing committed at height=%v and round=%v (invalid block: %v)", propose.height, propose.round, err)
 			}
 		}
 	}
@@ -539,7 +539,7 @@ func (p *Process) syncLatestCommit(latestCommit LatestCommit) {
 	// Check the proposed block and previous block without historical data. It
 	// needs the validator to store the previous execute state.
 	if err := p.validator.IsBlockValid(latestCommit.Block, false); err != nil {
-		p.logger.Infof("failed to validate block at height=%v and round=%v (err = %v)", latestCommit.Block.Header().Height(), latestCommit.Block.Header().Round(), err)
+		p.logger.Warnf("error syncing to height=%v and round=%v (invalid block: %v)", latestCommit.Block.Header().Height(), latestCommit.Block.Header().Round(), err)
 		return
 	}
 

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ecdsa"
 	cRand "crypto/rand"
 	"encoding/json"
+	"fmt"
 	"math/rand"
 	"time"
 
@@ -138,7 +139,7 @@ var _ = Describe("Process", func() {
 						privateKey := newEcdsaKey()
 						scheduler := NewMockScheduler(id.NewSignatory(privateKey.PublicKey))
 						processOrigin.Scheduler = scheduler
-						processOrigin.Validator = NewMockValidator(false)
+						processOrigin.Validator = NewMockValidator(fmt.Errorf(""))
 						process := processOrigin.ToProcess()
 
 						// Generate a invalid proposal
@@ -501,7 +502,7 @@ var _ = Describe("Process", func() {
 						processOrigin.State.CurrentHeight = height
 						processOrigin.State.CurrentRound = round
 						processOrigin.State.CurrentStep = StepPropose
-						processOrigin.Validator = NewMockValidator(false)
+						processOrigin.Validator = NewMockValidator(fmt.Errorf(""))
 						process := processOrigin.ToProcess()
 
 						// Send the proposal

--- a/replica/rebase.go
+++ b/replica/rebase.go
@@ -128,12 +128,18 @@ func (rebaser *shardRebaser) IsBlockValid(proposedBlock block.Block, checkHistor
 		if !proposedBlock.Header().Signatories().Equal(rebaser.expectedRebaseSigs) {
 			return fmt.Errorf("unexpected signatories in rebase block: expected %d, got %d", len(rebaser.expectedRebaseSigs), len(proposedBlock.Header().Signatories()))
 		}
+		// TODO: Transactions are expected to be nil (the plan is not expected
+		// to be nil, because there are "default" computations that might need
+		// to be done every block).
 
 	case block.Base:
 		if !proposedBlock.Header().Signatories().Equal(rebaser.expectedRebaseSigs) {
 			return fmt.Errorf("unexpected signatories in base block: expected %d, got %d", len(rebaser.expectedRebaseSigs), len(proposedBlock.Header().Signatories()))
 		}
 		if proposedBlock.Data() != nil {
+			// TODO: Transactions are expected to be nil (the plan is not expected
+			// to be nil, because there are "default" computations that might need
+			// to be done every block).
 			return fmt.Errorf("expected base block to have nil data")
 		}
 
@@ -150,7 +156,7 @@ func (rebaser *shardRebaser) IsBlockValid(proposedBlock block.Block, checkHistor
 	if checkHistory {
 		parentBlock, ok := rebaser.blockStorage.Blockchain(rebaser.shard).BlockAtHeight(proposedBlock.Header().Height() - 1)
 		if !ok {
-			return fmt.Errorf("failed to fetch block at height=%d", proposedBlock.Header().Height()-1)
+			return fmt.Errorf("block at height=%d not found", proposedBlock.Header().Height()-1)
 		}
 		if proposedBlock.Header().Timestamp() < parentBlock.Header().Timestamp() {
 			return fmt.Errorf("expected timestamp for proposed block to be greater than parent block")

--- a/replica/rebase.go
+++ b/replica/rebase.go
@@ -26,7 +26,7 @@ type BlockIterator interface {
 }
 
 type Validator interface {
-	IsBlockValid(block block.Block, checkHistory bool, shard Shard) bool
+	IsBlockValid(block block.Block, checkHistory bool, shard Shard) error
 }
 
 type Observer interface {
@@ -110,31 +110,31 @@ func (rebaser *shardRebaser) BlockProposal(height block.Height, round block.Roun
 	return block.New(header, data, prevState)
 }
 
-func (rebaser *shardRebaser) IsBlockValid(proposedBlock block.Block, checkHistory bool) bool {
+func (rebaser *shardRebaser) IsBlockValid(proposedBlock block.Block, checkHistory bool) error {
 	rebaser.mu.Lock()
 	defer rebaser.mu.Unlock()
 
 	// Check the expected `block.Kind`
 	if proposedBlock.Header().Kind() != rebaser.expectedKind {
-		return false
+		return fmt.Errorf("unexpected block kind: expected %v, got %v", rebaser.expectedKind, proposedBlock.Header().Kind())
 	}
 	switch proposedBlock.Header().Kind() {
 	case block.Standard:
 		if proposedBlock.Header().Signatories() != nil {
-			return false
+			return fmt.Errorf("expected standard block to have nil signatories")
 		}
 
 	case block.Rebase:
 		if !proposedBlock.Header().Signatories().Equal(rebaser.expectedRebaseSigs) {
-			return false
+			return fmt.Errorf("unexpected signatories in rebase block: expected %d, got %d", len(rebaser.expectedRebaseSigs), len(proposedBlock.Header().Signatories()))
 		}
 
 	case block.Base:
 		if !proposedBlock.Header().Signatories().Equal(rebaser.expectedRebaseSigs) {
-			return false
+			return fmt.Errorf("unexpected signatories in base block: expected %d, got %d", len(rebaser.expectedRebaseSigs), len(proposedBlock.Header().Signatories()))
 		}
 		if proposedBlock.Data() != nil {
-			return false
+			return fmt.Errorf("expected base block to have nil data")
 		}
 
 	default:
@@ -143,46 +143,46 @@ func (rebaser *shardRebaser) IsBlockValid(proposedBlock block.Block, checkHistor
 
 	// Check the expected `block.Hash`
 	if !proposedBlock.Hash().Equal(block.ComputeHash(proposedBlock.Header(), proposedBlock.Data(), proposedBlock.PreviousState())) {
-		return false
+		return fmt.Errorf("unexpected block hash for proposed block")
 	}
 
 	// Check against the parent `block.Block`
 	if checkHistory {
 		parentBlock, ok := rebaser.blockStorage.Blockchain(rebaser.shard).BlockAtHeight(proposedBlock.Header().Height() - 1)
 		if !ok {
-			return false
+			return fmt.Errorf("failed to fetch block at height=%d", proposedBlock.Header().Height()-1)
 		}
 		if proposedBlock.Header().Timestamp() < parentBlock.Header().Timestamp() {
-			return false
+			return fmt.Errorf("expected timestamp for proposed block to be greater than parent block")
 		}
 		if proposedBlock.Header().Timestamp() > block.Timestamp(time.Now().Unix()) {
-			return false
+			return fmt.Errorf("expected timestamp for proposed block to be less than current time")
 		}
 		if !proposedBlock.Header().ParentHash().Equal(parentBlock.Hash()) {
-			return false
+			return fmt.Errorf("expected parent hash for proposed block to equal parent block hash")
 		}
 
 		// Check that the parent is the most recently finalised
 		latestBlock := rebaser.blockStorage.LatestBlock(rebaser.shard)
 		if !parentBlock.Hash().Equal(latestBlock.Hash()) {
-			return false
+			return fmt.Errorf("expected parent block hash to equal latest block hash")
 		}
 		if parentBlock.Hash().Equal(block.InvalidHash) {
-			return false
+			return fmt.Errorf("parent block hash should not be invalid")
 		}
 	}
 
 	// Check against the base `block.Block`
 	baseBlock := rebaser.blockStorage.LatestBaseBlock(rebaser.shard)
 	if !proposedBlock.Header().BaseHash().Equal(baseBlock.Hash()) {
-		return false
+		return fmt.Errorf("expected base hash for proposed block to equal base block hash")
 	}
 
 	// Pass to the next `process.Validator`
 	if rebaser.validator != nil {
 		return rebaser.validator.IsBlockValid(proposedBlock, checkHistory, rebaser.shard)
 	}
-	return true
+	return nil
 }
 
 func (rebaser *shardRebaser) DidCommitBlock(height block.Height) {

--- a/replica/rebase_test.go
+++ b/replica/rebase_test.go
@@ -51,7 +51,7 @@ var _ = Describe("shardRebaser", func() {
 			test := func(shard Shard) bool {
 				store, initHeight, _ := initStorage(shard)
 				iter := mockBlockIterator{}
-				validator := newMockValidator(true)
+				validator := newMockValidator(nil)
 				rebaser := newShardRebaser(store, iter, validator, nil, shard)
 
 				// Generate a valid propose block.
@@ -64,7 +64,7 @@ var _ = Describe("shardRebaser", func() {
 				header.Timestamp = block.Timestamp(time.Now().Unix())
 				proposedBlock := block.New(header.ToBlockHeader(), nil, nil)
 
-				return rebaser.IsBlockValid(proposedBlock, true)
+				return rebaser.IsBlockValid(proposedBlock, true) == nil
 			}
 
 			Expect(quick.Check(test, nil)).Should(Succeed())
@@ -166,7 +166,7 @@ var _ = Describe("shardRebaser", func() {
 				header.Timestamp = block.Timestamp(time.Now().Unix() - 1)
 				header.Signatories = sigs
 				rebaseBlock := block.New(header.ToBlockHeader(), nil, nil)
-				Expect(rebaser.IsBlockValid(rebaseBlock, true)).Should(BeTrue())
+				Expect(rebaser.IsBlockValid(rebaseBlock, true)).Should(BeNil())
 
 				// After the block been committed
 				commitBlock(store, shard, rebaseBlock)
@@ -182,7 +182,7 @@ var _ = Describe("shardRebaser", func() {
 				baseHeader.Signatories = sigs
 				baseBlock := block.New(baseHeader.ToBlockHeader(), nil, nil)
 
-				return rebaser.IsBlockValid(baseBlock, true)
+				return rebaser.IsBlockValid(baseBlock, true) == nil
 			}
 			Expect(quick.Check(test, nil)).Should(Succeed())
 		})

--- a/replica/replica_suite_test.go
+++ b/replica/replica_suite_test.go
@@ -76,14 +76,14 @@ func (m mockBlockIterator) NextBlock(kind block.Kind, height block.Height, shard
 }
 
 type mockValidator struct {
-	valid bool
+	valid error
 }
 
-func (m mockValidator) IsBlockValid(block.Block, bool, Shard) bool {
+func (m mockValidator) IsBlockValid(block.Block, bool, Shard) error {
 	return m.valid
 }
 
-func newMockValidator(valid bool) Validator {
+func newMockValidator(valid error) Validator {
 	return mockValidator{valid: valid}
 }
 

--- a/testutil/process.go
+++ b/testutil/process.go
@@ -180,7 +180,7 @@ func NewProcessOrigin(f int) ProcessOrigin {
 		BroadcastMessages: messages,
 
 		Proposer:    NewMockProposer(privateKey),
-		Validator:   NewMockValidator(true),
+		Validator:   NewMockValidator(nil),
 		Scheduler:   NewMockScheduler(sig),
 		Broadcaster: NewMockBroadcaster(messages),
 		Timer:       NewMockTimer(1 * time.Second),
@@ -296,14 +296,14 @@ func (m *MockProposer) BlockProposal(height block.Height, round block.Round) blo
 }
 
 type MockValidator struct {
-	valid bool
+	valid error
 }
 
-func NewMockValidator(valid bool) process.Validator {
+func NewMockValidator(valid error) process.Validator {
 	return MockValidator{valid: valid}
 }
 
-func (m MockValidator) IsBlockValid(block.Block, bool) bool {
+func (m MockValidator) IsBlockValid(block.Block, bool) error {
 	return m.valid
 }
 

--- a/testutil/replica/replica.go
+++ b/testutil/replica/replica.go
@@ -80,23 +80,23 @@ func NewMockValidator(store *MockPersistentStorage) replica.Validator {
 	}
 }
 
-func (m *MockValidator) IsBlockValid(b block.Block, checkHistory bool, shard replica.Shard) bool {
+func (m *MockValidator) IsBlockValid(b block.Block, checkHistory bool, shard replica.Shard) error {
 	height := b.Header().Height()
 	prevState := b.PreviousState()
 
 	blockchain := m.store.MockBlockchain(shard)
 	if !checkHistory {
-		return true
+		return nil
 	}
 
 	state, ok := blockchain.StateAtHeight(height - 1)
 	if !ok {
-		return false
+		return fmt.Errorf("failed to get state at height %d", height-1)
 	}
 	if !bytes.Equal(prevState, state) {
-		return false
+		return fmt.Errorf("invalid previous state")
 	}
-	return true
+	return nil
 }
 
 type MockObserver struct {


### PR DESCRIPTION
Update `IsBlockValid` interface to return an error instead of a boolean variable. This allows us to log the validation result with greater ease.