### PR TITLE
Use sha256 instead of sha3-256

### DIFF
--- a/block/block.go
+++ b/block/block.go
@@ -1,12 +1,12 @@
 package block
 
 import (
+	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 	"time"
 
 	"github.com/renproject/id"
-	"golang.org/x/crypto/sha3"
 )
 
 // Kind defines the different kinds of Block that exist.
@@ -190,7 +190,7 @@ func New(header Header, data Data, prevState State) Block {
 	}
 }
 
-// Hash returns the 256-bit SHA3 Hash of the Header and Data.
+// Hash returns the 256-bit SHA2 Hash of the Header and Data.
 func (block Block) Hash() id.Hash {
 	return block.hash
 }
@@ -243,5 +243,5 @@ var (
 
 // ComputeHash of a block basing on its header, data and previous state.
 func ComputeHash(header Header, data Data, prevState State) id.Hash {
-	return sha3.Sum256([]byte(fmt.Sprintf("BlockHash(Header=%v,Data=%v,PreviousState=%v)", header, data, prevState)))
+	return sha256.Sum256([]byte(fmt.Sprintf("BlockHash(Header=%v,Data=%v,PreviousState=%v)", header, data, prevState)))
 }

--- a/process/message.go
+++ b/process/message.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"crypto/ecdsa"
+	"crypto/sha256"
 	"encoding"
 	"encoding/json"
 	"fmt"
@@ -9,7 +10,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/renproject/hyperdrive/block"
 	"github.com/renproject/id"
-	"golang.org/x/crypto/sha3"
 )
 
 type MessageType uint64
@@ -115,7 +115,7 @@ func (propose *Propose) Signatory() id.Signatory {
 }
 
 func (propose *Propose) SigHash() id.Hash {
-	return sha3.Sum256([]byte(propose.String()))
+	return sha256.Sum256([]byte(propose.String()))
 }
 
 func (propose *Propose) Sig() id.Signature {
@@ -173,7 +173,7 @@ func (prevote *Prevote) Signatory() id.Signatory {
 }
 
 func (prevote *Prevote) SigHash() id.Hash {
-	return sha3.Sum256([]byte(prevote.String()))
+	return sha256.Sum256([]byte(prevote.String()))
 }
 
 func (prevote *Prevote) Sig() id.Signature {
@@ -223,7 +223,7 @@ func (precommit *Precommit) Signatory() id.Signatory {
 }
 
 func (precommit *Precommit) SigHash() id.Hash {
-	return sha3.Sum256([]byte(precommit.String()))
+	return sha256.Sum256([]byte(precommit.String()))
 }
 
 func (precommit *Precommit) Sig() id.Signature {

--- a/testutil/replica/replica.go
+++ b/testutil/replica/replica.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/ecdsa"
 	"crypto/rand"
+	"crypto/sha256"
 	"fmt"
 	mrand "math/rand"
 	"sync"
@@ -15,7 +16,6 @@ import (
 	"github.com/renproject/hyperdrive/testutil"
 	"github.com/renproject/id"
 	"github.com/renproject/phi"
-	"golang.org/x/crypto/sha3"
 )
 
 func Contain(list []int, target int) bool {
@@ -115,7 +115,7 @@ func (m MockObserver) DidCommitBlock(height block.Height, shard replica.Shard) {
 	if !ok {
 		panic("DidCommitBlock should be called only when the block has been added to storage")
 	}
-	digest := sha3.Sum256(b.Data())
+	digest := sha256.Sum256(b.Data())
 	blockchain.InsertBlockStatAtHeight(height, digest[:])
 
 	// Insert executed state of the previous height


### PR DESCRIPTION
We cannot verify on-chain on the EVM the sha3 hash of messages. This PR switches the hash function from SHA3-256 to SHA-256.