### PR TITLE
Fix integration tests

### DIFF
--- a/block/marshal_test.go
+++ b/block/marshal_test.go
@@ -1,2 +1,1 @@
 package block_test
-

--- a/process/marshal_test.go
+++ b/process/marshal_test.go
@@ -1,2 +1,1 @@
 package process_test
-

--- a/testutil/block.go
+++ b/testutil/block.go
@@ -1,30 +1,22 @@
 package testutil
 
 import (
-	"fmt"
 	"math/rand"
-	"reflect"
-	"testing/quick"
 	"time"
 
 	"github.com/renproject/hyperdrive/block"
 	"github.com/renproject/id"
 )
 
-var r *rand.Rand
-
-func init() {
-	r = rand.New(rand.NewSource(time.Now().Unix()))
-}
-
 // RandomBytesSlice returns a random bytes slice.
 func RandomBytesSlice() []byte {
-	t := reflect.TypeOf([]byte{})
-	value, ok := quick.Value(t, r)
-	if !ok {
-		panic(fmt.Sprintf("cannot generate random value of type %v", t.Name()))
+	length := rand.Intn(256)
+	slice := make([]byte, length)
+	_, err := rand.Read(slice)
+	if err != nil {
+		panic(err)
 	}
-	return value.Interface().([]byte)
+	return slice
 }
 
 // RandomBlockKind returns a random valid block kind.


### PR DESCRIPTION
The integration tests are sometimes failing. This PR tries to fix the test with following major updates.

- The redundant nodes used to be first couple nodes instead of the last couple ones. When we trying to block nodes' connection or shut them down, there's a chance we shut down a redundant node which wouldn't do anything for the test. 
- In `testutil`, we use a `rand.Rand` to generate random bytes slice which confirmed to be not concurrent-safe and this would cause data racing for some of the test cases. We remove the `rand.Rand` and use a different way to generate random bytes slice
- In the integration tests, we introduce random delays for all nodes when starting.  We used to test crashing after a couple of seconds, but this cannot guarantee all nodes are in the same stage. (i.e. node `i` starts late and we crash `f` nodes in the network before node `i` catches up, in this case `f+1` won't participate consensus) . We change the test to first wait for consensus reached across all nodes, then start testing crushing and blocking.