### PR TITLE
Update DidReceiveSufficientNilPrevotes interface and reduce threshold

### DIFF
--- a/replica/rebase.go
+++ b/replica/rebase.go
@@ -31,7 +31,7 @@ type Validator interface {
 
 type Observer interface {
 	DidCommitBlock(block.Height, Shard)
-	DidReceiveSufficientNilPrevotes(messages process.Messages, threshold int)
+	DidReceiveSufficientNilPrevotes(messages process.Messages, f int)
 	IsSignatory(Shard) bool
 }
 
@@ -222,9 +222,9 @@ func (rebaser *shardRebaser) DidCommitBlock(height block.Height) {
 	}
 }
 
-func (rebaser *shardRebaser) DidReceiveSufficientNilPrevotes(messages process.Messages, threshold int) {
+func (rebaser *shardRebaser) DidReceiveSufficientNilPrevotes(messages process.Messages, f int) {
 	if rebaser.observer != nil {
-		rebaser.observer.DidReceiveSufficientNilPrevotes(messages, threshold)
+		rebaser.observer.DidReceiveSufficientNilPrevotes(messages, f)
 	}
 }
 


### PR DESCRIPTION
The interface of the `DidReceiveSufficientNilPrevotes` has been updated to pass `F` instead of an arbitrary threshold to provide more context as to what the threshold value is. Additionally, this function is now called when we observe `F+1` nil prevotes instead of `2F+1` as it is assumed that `F` is the maximum number of adversaries.