### PR TITLE
Notify observer regarding sufficient nil prevotes only if we are the proposer

### DIFF
--- a/process/message.go
+++ b/process/message.go
@@ -467,6 +467,7 @@ func (inbox *Inbox) QueryByHeightRound(height block.Height, round block.Round) (
 	return
 }
 
+func (inbox *Inbox) F() int {
 	return inbox.f
 }
 

--- a/process/process.go
+++ b/process/process.go
@@ -320,7 +320,10 @@ func (p *Process) handlePrevote(prevote *Prevote) {
 
 	// upon f+1 Prevote{currentHeight, currentRound, nil}
 	if n := p.state.Prevotes.QueryByHeightRoundBlockHash(p.state.CurrentHeight, p.state.CurrentRound, block.InvalidHash); n > p.state.Prevotes.F() {
-		p.observer.DidReceiveSufficientNilPrevotes(p.state.Prevotes.QueryMessagesByHeightRound(p.state.CurrentHeight, p.state.CurrentRound), p.state.Prevotes.F())
+		// if we are the proposer
+		if p.signatory.Equal(p.scheduler.Schedule(p.state.CurrentHeight, p.state.CurrentRound)) {
+			p.observer.DidReceiveSufficientNilPrevotes(p.state.Prevotes.QueryMessagesByHeightRound(p.state.CurrentHeight, p.state.CurrentRound), p.state.Prevotes.F())
+		}
 	}
 
 	// upon 2f+1 Prevote{currentHeight, currentRound, nil} while currentStep = StepPrevote


### PR DESCRIPTION
`DidReceiveSufficientNilPrevotes` should only ever be called to notify the proposer that their propose has been rejected. Prior to this change all participants were being notified.