### PR TITLE
Restart process timer on boot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2.1
 
 _defaults: &defaults
     docker:
-      - image: circleci/golang:1.11
+      - image: circleci/golang:1.13
 
 jobs:
   build:

--- a/process/process.go
+++ b/process/process.go
@@ -171,15 +171,15 @@ func (p *Process) Start() {
 	}
 
 	// Start the Process from previous state.
-	switch p.state.CurrentStep{
+	switch p.state.CurrentStep {
 	case StepNil, StepPropose:
 		p.startRound(p.state.CurrentRound)
 	case StepPrevote:
-		if numPrevotes >= 2 * p.state.Prevotes.f + 1{
+		if numPrevotes >= 2*p.state.Prevotes.f+1 {
 			p.scheduleTimeoutPrevote(p.state.CurrentHeight, p.state.CurrentRound, p.timer.Timeout(StepPrevote, p.state.CurrentRound))
 		}
 	case StepPrecommit:
-		if numPrecommits >= 2 * p.state.Precommits.f + 1{
+		if numPrecommits >= 2*p.state.Precommits.f+1 {
 			p.scheduleTimeoutPrecommit(p.state.CurrentHeight, p.state.CurrentRound, p.timer.Timeout(StepPrecommit, p.state.CurrentRound))
 		}
 	default:

--- a/process/process.go
+++ b/process/process.go
@@ -170,8 +170,20 @@ func (p *Process) Start() {
 		}
 	}
 
-	if p.state.CurrentStep <= StepPropose {
+	// Start the Process from previous state.
+	switch p.state.CurrentStep{
+	case StepNil, StepPropose:
 		p.startRound(p.state.CurrentRound)
+	case StepPrevote:
+		if numPrevotes >= 2 * p.state.Prevotes.f + 1{
+			p.scheduleTimeoutPrevote(p.state.CurrentHeight, p.state.CurrentRound, p.timer.Timeout(StepPrevote, p.state.CurrentRound))
+		}
+	case StepPrecommit:
+		if numPrecommits >= 2 * p.state.Precommits.f + 1{
+			p.scheduleTimeoutPrecommit(p.state.CurrentHeight, p.state.CurrentRound, p.timer.Timeout(StepPrecommit, p.state.CurrentRound))
+		}
+	default:
+		panic("unknown step value")
 	}
 }
 

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -364,12 +364,12 @@ var _ = Describe("Process", func() {
 		})
 	})
 
-	Context("when the process is in prevote step", func() {
-		Context("when receive 2*f +1 prevote of any proposal for the first time", func() {
-			It("should send a nil precommit when nothing changes after the timeout", func() {
+	Context("when the process is in the prevote step", func() {
+		Context("when it receives 2*f+1 prevotes for any proposal for the first time", func() {
+			It("should send a nil precommit if no consensus is reached within the timeout", func() {
 				By("before reboot")
 
-				// Initialise a new process at thee prevote step.
+				// Initialise a new process at the prevote step.
 				f := rand.Intn(100) + 1
 				height, round := block.Height(rand.Int()), block.Round(rand.Int())
 				processOrigin := NewProcessOrigin(f)
@@ -427,8 +427,8 @@ var _ = Describe("Process", func() {
 			})
 		})
 
-		Context("when receive 2*f +1 nil prevote of current height and round", func() {
-			It("should broadcast a nl precommit and move to precommit state", func() {
+		Context("when it receives 2*f+1 nil prevotes for the current height and round", func() {
+			It("should broadcast a nil precommit and move to the precommit step", func() {
 				f := rand.Intn(100) + 1
 				height, round := block.Height(rand.Int()), block.Round(rand.Int())
 				processOrigin := NewProcessOrigin(f)
@@ -456,7 +456,7 @@ var _ = Describe("Process", func() {
 		})
 	})
 
-	Context("when the process receive at least 2*f + 1 of any precommit", func() {
+	Context("when the process receives at least 2*f+1 precommits", func() {
 		Context("when starting a timer before executing the OnTimeoutPrecommit function", func() {
 			It("should start a round when nothing changes after the timeout", func() {
 				for _, step := range []Step{StepPropose, StepPrevote, StepPrecommit} {

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -725,6 +725,15 @@ var _ = Describe("Process", func() {
 	})
 
 	Context("when starting the process", func() {
+		It("should panic if the step is invalid", func() {
+			processOrigin := NewProcessOrigin(100)
+			processOrigin.State.CurrentStep = Step(100)
+			process := processOrigin.ToProcess()
+			Expect(func() {
+				process.Start()
+			}).Should(Panic())
+		})
+
 		Context("when the process has messages from a previous height", func() {
 			It("should resend the most recent proposal, prevote, and precommit", func() {
 				processOrigin := NewProcessOrigin(100)

--- a/testutil/process.go
+++ b/testutil/process.go
@@ -192,7 +192,7 @@ func NewProcessOrigin(f int) ProcessOrigin {
 	}
 }
 
-func (p ProcessOrigin) UpdateState(state process.State) {
+func (p *ProcessOrigin) UpdateState(state process.State) {
 	p.State = state
 }
 

--- a/testutil/process.go
+++ b/testutil/process.go
@@ -192,6 +192,10 @@ func NewProcessOrigin(f int) ProcessOrigin {
 	}
 }
 
+func (p ProcessOrigin) UpdateState(state process.State) {
+	p.State = state
+}
+
 func (p ProcessOrigin) ToProcess() *process.Process {
 	return process.New(
 		logrus.StandardLogger(),


### PR DESCRIPTION
`Process` will start a timer when first time receives 2f+1 prevotes/precommits. If the process stops before the timer expires, it will not start a new timer when restarting, this could cause process stuck in prevote/precommit step and never move on.