### PR TITLE
Resend our prevote for the locked round inside a propose

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -160,19 +160,14 @@ func (p *Process) Start() {
 	p.broadcaster.Broadcast(resync)
 
 	// Start the Process from previous state.
-	switch p.state.CurrentStep {
-	case StepNil, StepPropose:
+	if p.state.CurrentStep == StepNil || p.state.CurrentStep == StepPropose {
 		p.startRound(p.state.CurrentRound)
-	case StepPrevote:
-		if numPrevotes >= 2*p.state.Prevotes.f+1 {
-			p.scheduleTimeoutPrevote(p.state.CurrentHeight, p.state.CurrentRound, p.timer.Timeout(StepPrevote, p.state.CurrentRound))
-		}
-	case StepPrecommit:
-		if numPrecommits >= 2*p.state.Precommits.f+1 {
-			p.scheduleTimeoutPrecommit(p.state.CurrentHeight, p.state.CurrentRound, p.timer.Timeout(StepPrecommit, p.state.CurrentRound))
-		}
-	default:
-		panic("unknown step value")
+	}
+	if numPrevotes >= 2*p.state.Prevotes.f+1 && p.state.CurrentStep == StepPrevote {
+		p.scheduleTimeoutPrevote(p.state.CurrentHeight, p.state.CurrentRound, p.timer.Timeout(StepPrevote, p.state.CurrentRound))
+	}
+	if numPrecommits >= 2*p.state.Precommits.f+1 {
+		p.scheduleTimeoutPrecommit(p.state.CurrentHeight, p.state.CurrentRound, p.timer.Timeout(StepPrecommit, p.state.CurrentRound))
 	}
 }
 

--- a/process/process.go
+++ b/process/process.go
@@ -328,10 +328,13 @@ func (p *Process) handlePropose(propose *Propose) {
 		}
 	}
 
-	// Resend our prevote from the valid round in case of missed messages.
+	// Resend our prevote from the valid round if it exists in case of missed
+	// messages.
 	if propose.ValidRound() > block.InvalidRound {
 		prevote := p.state.Prevotes.QueryByHeightRoundSignatory(propose.Height(), propose.ValidRound(), p.signatory)
-		p.broadcaster.Broadcast(prevote)
+		if prevote != nil {
+			p.broadcaster.Broadcast(prevote)
+		}
 	}
 
 	// upon f+1 *{currentHeight, round, *, *} and round > currentRound

--- a/process/process.go
+++ b/process/process.go
@@ -328,6 +328,12 @@ func (p *Process) handlePropose(propose *Propose) {
 		}
 	}
 
+	// Resend our prevote from the valid round in case of missed messages.
+	if propose.ValidRound() > block.InvalidRound {
+		prevote := p.state.Prevotes.QueryByHeightRoundSignatory(propose.Height(), propose.ValidRound(), p.signatory)
+		p.broadcaster.Broadcast(prevote)
+	}
+
 	// upon f+1 *{currentHeight, round, *, *} and round > currentRound
 	n := p.numberOfMessagesAtCurrentHeight(propose.Round())
 	if n > p.state.Prevotes.F() && propose.Height() == p.state.CurrentHeight && propose.Round() > p.state.CurrentRound {

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -766,15 +766,6 @@ var _ = Describe("Process", func() {
 			Expect(ok).Should(BeTrue())
 		})
 
-		It("should panic if the step is invalid", func() {
-			processOrigin := NewProcessOrigin(100)
-			processOrigin.State.CurrentStep = Step(100)
-			process := processOrigin.ToProcess()
-			Expect(func() {
-				process.Start()
-			}).Should(Panic())
-		})
-
 		Context("when the process has messages from a previous height", func() {
 			It("should resend the most recent proposal, prevote, and precommit", func() {
 				processOrigin := NewProcessOrigin(100)


### PR DESCRIPTION
This PR fixes an issue with consensus that may arise from messages being dropped at a certain height or round. Specifically, the network can end up in a partitioned state if a subset of the validators (less than `2f+1`) receive sufficient non-nil prevotes for a given propose, while the remaining nodes _do not_ meaning they precommit nil. The validators then progress to the next round and do so indefinitely as the two groups will never agree on a proposal from an opposing group. To fix this, upon receiving a proposal with a valid round we simply broadcast our prevote for that given round to others.

Additionally, this PR fixes the logic for scheduling timeouts on boot. Previously validators would only schedule the precommit timeout if they were at the precommit step, whereas based on the specification this timer should be started regardless of what step they are in, so long as the number of precommits exceeds `2f`.

Finally, the logic for calling `startRound` inside the message handlers was incorrect as it used the number of unique messages for the given message type to calculate `n`. This should instead be the total number of unique messages at a given height and round _irrespective of type_.