### PR TITLE
Remove TODO comment 

### DIFF
--- a/replica/rebase.go
+++ b/replica/rebase.go
@@ -136,9 +136,6 @@ func (rebaser *shardRebaser) IsBlockValid(proposedBlock block.Block, checkHistor
 		if !proposedBlock.Header().Signatories().Equal(rebaser.expectedRebaseSigs) {
 			return nilReasons, fmt.Errorf("unexpected signatories in rebase block: expected %d, got %d", len(rebaser.expectedRebaseSigs), len(proposedBlock.Header().Signatories()))
 		}
-		// TODO: Transactions are expected to be nil (the plan is not expected
-		// to be nil, because there are "default" computations that might need
-		// to be done every block).
 
 	case block.Base:
 		if !proposedBlock.Header().Signatories().Equal(rebaser.expectedRebaseSigs) {


### PR DESCRIPTION
This PR removes a TODO comment in `replica/rebase.go`:

```go
// TODO: Transactions are expected to be nil (the plan is not expected
// to be nil, because there are "default" computations that might need
// to be done every block).
```

This is not necessarily true, and having non-nil transactions will not affect the correctness of rebasing in all cases. Users can add this in as part of their own validation logic if it is necessary for their use-case.