### PR TITLE
Enforce 3F+1 signatories on rebase

### DIFF
--- a/replica/replica.go
+++ b/replica/replica.go
@@ -163,6 +163,9 @@ func (replica *Replica) HandleMessage(m Message) {
 }
 
 func (replica *Replica) Rebase(sigs id.Signatories) {
+	if len(sigs)%3 != 1 {
+		panic(fmt.Errorf("invariant violation: number of nodes needs to be 3f +1, got %v", len(sigs)))
+	}
 	replica.scheduler.rebase(sigs)
 	replica.rebaser.rebase(sigs)
 }


### PR DESCRIPTION
Before this PR, `Rebase` would not enforce that the number of signatories being proposed by the rebase was 3F+1. This PR fixes that by panicking with the same invariant message as `New` if the number of signatories in the rebase is not 3F+1.