### PR TITLE
Check propose schedule before insert propose

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,6 @@ go 1.13
 
 require (
 	github.com/ethereum/go-ethereum v1.9.5
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
 	github.com/renproject/abi v0.4.1

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -543,7 +543,12 @@ var _ = Describe("Process", func() {
 	Context("when receiving f+1 of any message whose round is higher", func() {
 		It("should start that round", func() {
 			for _, t := range []MessageType{
-				ProposeMessageType,
+				// NOTE: You should only ever receive 1 Propose for a height
+				// and round, so this test is not meaningful for Propose
+				// messages.
+				//
+				//	ProposeMessageType,
+				//
 				PrevoteMessageType,
 				PrecommitMessageType,
 			} {

--- a/replica/replica_test.go
+++ b/replica/replica_test.go
@@ -75,19 +75,26 @@ var _ = Describe("Replica", func() {
 					replica := New(Options{}, pstore, store, mockBlockIterator{}, nil, nil, broadcaster, shard, *newEcdsaKey())
 
 					pMessage := RandomMessage(process.ProposeMessageType)
-					key := keys[0]
-					Expect(process.Sign(pMessage, *key)).Should(Succeed())
-					message := Message{
-						Shard:   shard,
-						Message: pMessage,
-					}
-					replica.HandleMessage(message)
+					numStored := 0
+					// Only one proposer is valid, so only one propose should
+					// end up stored in the Process state.
+					for _, key := range keys {
+						Expect(process.Sign(pMessage, *key)).Should(Succeed())
+						message := Message{
+							Shard:   shard,
+							Message: pMessage,
+						}
+						replica.HandleMessage(message)
 
-					// Expect the message not been inserted into the specific inbox,
-					// which indicating the message not passed to the process.
-					state := testutil.GetStateFromProcess(replica.p, 2)
-					stored := state.Proposals.QueryByHeightRoundSignatory(pMessage.Height(), pMessage.Round(), pMessage.Signatory())
-					Expect(reflect.DeepEqual(stored, pMessage)).Should(BeTrue())
+						// Expect the message not been inserted into the specific inbox,
+						// which indicating the message not passed to the process.
+						state := testutil.GetStateFromProcess(replica.p, 2)
+						stored := state.Proposals.QueryByHeightRoundSignatory(pMessage.Height(), pMessage.Round(), pMessage.Signatory())
+						if reflect.DeepEqual(stored, pMessage) {
+							numStored++
+						}
+					}
+					Expect(numStored).To(Equal(1))
 
 					return true
 				}


### PR DESCRIPTION
Fixes #64.

This PR checks the schedule before inserting a `Propose` message. It uses the height and round of the `Propose` message for checking the schedule, because an out-of-sync `Process` may see the `Propose` as "from the future".