### PR TITLE
Ignore message from old heights

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,6 @@ go 1.13
 
 require (
 	github.com/ethereum/go-ethereum v1.9.5
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
 	github.com/renproject/abi v0.4.1

--- a/process/process.go
+++ b/process/process.go
@@ -133,6 +133,13 @@ func New(logger logrus.FieldLogger, signatory id.Signatory, blockchain Blockchai
 	return p
 }
 
+// CurrentHeight of the Process.
+func (p *Process) CurrentHeight() block.Height {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.state.CurrentHeight
+}
+
 // Save the current state of the process using the saveRestorer.
 func (p *Process) Save() {
 	p.mu.Lock()


### PR DESCRIPTION
This PR fixes #46. Messages from previous heights cannot affect current/future heights, and so there is no point wasting resources on processing them. This PR introduces the `CurrentHeight()` method to the `Process`, and the `Replica` checks `Message.Height() >= Process.CurrentHeight()` before doing any further processing of the message. Debug logs are emitted when the message is dropped because of this check.