### PR TITLE
Ignore duplicate messages

### DIFF
--- a/process/message.go
+++ b/process/message.go
@@ -446,6 +446,12 @@ func (inbox *Inbox) Insert(message Message) (n int, firstTime, firstTimeExceedin
 
 	previousN := len(inbox.messages[height][round])
 	_, ok := inbox.messages[height][round][signatory]
+	if ok {
+		// We do not override existing messages. This means that it is
+		// impossible for N to change, and thus for any "first time" triggers to
+		// become true.
+		return previousN, false, false, false, false
+	}
 
 	inbox.messages[height][round][signatory] = message
 


### PR DESCRIPTION
This PR fixes #47 and will not `Inbox.Insert` messages for which there is already a message at the given height, round, and signatory.