### PR TITLE
Implement message queue

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -350,8 +350,6 @@ func (p *Process) startRound(round block.Round) {
 }
 
 func (p *Process) handlePropose(propose *Propose) {
-	p.syncLatestCommit(propose.latestCommit)
-
 	// Before inserting the Propose, we need to check whether or not the Propose
 	// is from the scheduled Proposer. Otherwise, we can safely ignore it.
 	var firstTime bool
@@ -363,6 +361,8 @@ func (p *Process) handlePropose(propose *Propose) {
 		p.logger.Warnf("received propose at height=%v and round=%v from out-of-turn proposer=%v", propose.height, propose.round, propose.signatory)
 		return
 	}
+
+	p.syncLatestCommit(propose.latestCommit)
 
 	// upon Propose{currentHeight, currentRound, block, -1}
 	if propose.Height() == p.state.CurrentHeight && propose.Round() == p.state.CurrentRound && propose.ValidRound() == block.InvalidRound {

--- a/replica/mq.go
+++ b/replica/mq.go
@@ -25,6 +25,7 @@ type MessageQueue interface {
 	Push(process.Message)
 	PopUntil(block.Height) []process.Message
 	Peek() block.Height
+	Len() int
 }
 
 type messageQueue struct {
@@ -154,4 +155,11 @@ func (mq *messageQueue) Peek() block.Height {
 		return block.InvalidHeight
 	}
 	return mq.queue[0].Height()
+}
+
+func (mq *messageQueue) Len() int {
+	mq.mu.Lock()
+	defer mq.mu.Unlock()
+
+	return len(mq.queue)
 }

--- a/replica/mq.go
+++ b/replica/mq.go
@@ -1,0 +1,157 @@
+package replica
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/renproject/hyperdrive/block"
+	"github.com/renproject/hyperdrive/process"
+	"github.com/renproject/id"
+)
+
+// A MessageQueue is used to queue messages, and order them by height. It will
+// drop messages that are too far in the future. This helps protect honest
+// Replicas from being spammed by malicious Replicas with lots of "future"
+// messages in an attempt to waste processing time. It also makes the Process
+// easier to analyse, because it can assume that all messages will come in for
+// height H before height >H.
+//
+// The MessageQueue is not expected to protect against malicious Replicas that
+// spam lots of "future" rounds in any given height (this must be done
+// externally to the MessageQueue), and it is not expected to protect against
+// malicious Replicas that spam lots of "past" heights.
+type MessageQueue interface {
+	Push(process.Message)
+	PopUntil(block.Height) []process.Message
+	Peek() block.Height
+}
+
+type messageQueue struct {
+	// mu protects the entire message queue.
+	mu *sync.Mutex
+
+	// once is used to make sure that no signatory sends multiple messages with
+	// the same type at the same height and round.
+	once map[process.MessageType]map[block.Height]map[block.Round]map[id.Signatory]bool
+
+	// queue stores all messages, ordered first by height and then by round.
+	queue    []process.Message
+	queueMax int
+}
+
+// NewMessageQueue returns a new MessageQueue with a maximum capacity. Above
+// this capacity, messages with the greater height will be dropped.
+func NewMessageQueue(cap int) MessageQueue {
+	if cap <= 0 {
+		panic(fmt.Sprintf("message queue capacity too low: expected cap>0, got cap=%v", cap))
+	}
+	return &messageQueue{
+		mu:       new(sync.Mutex),
+		once:     map[process.MessageType]map[block.Height]map[block.Round]map[id.Signatory]bool{},
+		queue:    make([]process.Message, 0, cap),
+		queueMax: cap,
+	}
+}
+
+func (mq *messageQueue) Push(message process.Message) {
+	mq.mu.Lock()
+	defer mq.mu.Unlock()
+
+	if _, ok := mq.once[message.Type()][message.Height()][message.Round()][message.Signatory()]; ok {
+		// Ignore messages that appear in the "once" filter to protecte against
+		// malicious duplicates.
+		return
+	}
+
+	// If the queue is at maximum capacity, then we need to make room for the
+	// new message, or ignore the new message.
+	if len(mq.queue) >= mq.queueMax {
+		if mq.queue[len(mq.queue)-1].Height() < message.Height() {
+			// Drop the new message because it is too far in the future.
+			return
+		}
+		if mq.queue[len(mq.queue)-1].Height() == message.Height() {
+			if mq.queue[len(mq.queue)-1].Round() <= message.Round() {
+				// Drop the new message because it is too far in the future. We
+				// use the "or equals" check here to favour messages that are
+				// already in the queue.
+				return
+			}
+		}
+		// Truncate the queue to make room for the newer message.
+		mq.queue = mq.queue[:len(mq.queue)-1]
+	}
+
+	// Write the message to the "once" filter to protect against malicious
+	// duplicates.
+	if _, ok := mq.once[message.Type()]; !ok {
+		mq.once[message.Type()] = map[block.Height]map[block.Round]map[id.Signatory]bool{}
+	}
+	if _, ok := mq.once[message.Type()][message.Height()]; !ok {
+		mq.once[message.Type()][message.Height()] = map[block.Round]map[id.Signatory]bool{}
+	}
+	if _, ok := mq.once[message.Type()][message.Height()][message.Round()]; !ok {
+		mq.once[message.Type()][message.Height()][message.Round()] = map[id.Signatory]bool{}
+	}
+	mq.once[message.Type()][message.Height()][message.Round()][message.Signatory()] = true
+
+	// Find a place to insert the message in the queue.
+	insertAt := sort.Search(len(mq.queue), func(i int) bool {
+		if message.Height() < mq.queue[i].Height() {
+			return true
+		}
+		if message.Height() > mq.queue[i].Height() {
+			return false
+		}
+		return message.Round() < mq.queue[i].Round()
+	})
+	mq.queue = append(mq.queue[:insertAt], append([]process.Message{message}, mq.queue[insertAt:]...)...)
+}
+
+// PopUntil returns all messages up to, and including, the given height.
+func (mq *messageQueue) PopUntil(height block.Height) []process.Message {
+	mq.mu.Lock()
+	defer mq.mu.Unlock()
+
+	// There is nothing to return if the queue is empty.
+	if len(mq.queue) == 0 || mq.queue[0].Height() > height {
+		return []process.Message{}
+	}
+
+	// Store the beginning and end heights that will be dropped from the queue
+	// so that, at the end, we can drop them from the "once" filter.
+	beginHeight := mq.queue[0].Height()
+	endHeight := height
+
+	// Avoid allocations by returning the front end of the queue.
+	n := len(mq.queue)
+	for i, message := range mq.queue {
+		if message.Height() > height {
+			n = i
+			break
+		}
+	}
+	messages := mq.queue[:n]
+	mq.queue = mq.queue[n:]
+
+	// Drop all space in the filter.
+	for h := beginHeight; h < endHeight; h++ {
+		delete(mq.once[process.ProposeMessageType], h)
+		delete(mq.once[process.PrevoteMessageType], h)
+		delete(mq.once[process.PrecommitMessageType], h)
+	}
+	return messages
+}
+
+// Peek returns the smallest height in the queue. If there are no messages in
+// the queue, it returns an invalid height.
+func (mq *messageQueue) Peek() block.Height {
+	mq.mu.Lock()
+	defer mq.mu.Unlock()
+
+	if len(mq.queue) == 0 {
+		return block.InvalidHeight
+	}
+	return mq.queue[0].Height()
+}

--- a/replica/mq_test.go
+++ b/replica/mq_test.go
@@ -1,0 +1,14 @@
+package replica_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Message queue", func() {
+	Context("when pushing messages", func() {
+		It("should do something", func() {
+			Expect(func() { panic("unimplemented") }).ToNot(Panic())
+		})
+	})
+})

--- a/replica/mq_test.go
+++ b/replica/mq_test.go
@@ -1,14 +1,134 @@
 package replica_test
 
 import (
+	"math/rand"
+
+	"github.com/renproject/hyperdrive/block"
+	"github.com/renproject/hyperdrive/replica"
+	"github.com/renproject/hyperdrive/testutil"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Message queue", func() {
+	Context("when initialising", func() {
+		Context("when capacity is less than or equal to zero", func() {
+			It("should panic", func() {
+				Expect(func() { replica.NewMessageQueue(-1) }).To(Panic())
+				Expect(func() { replica.NewMessageQueue(0) }).To(Panic())
+			})
+		})
+	})
+
 	Context("when pushing messages", func() {
-		It("should do something", func() {
-			Expect(func() { panic("unimplemented") }).ToNot(Panic())
+		Context("when peeking", func() {
+			It("should return the lowest height", func() {
+				mq := replica.NewMessageQueue(100)
+				minHeight := block.Height(1<<63 - 1)
+				for i := 0; i < 100; i++ {
+					m := testutil.RandomMessage(testutil.RandomMessageType(true))
+					if m.Height() < minHeight {
+						minHeight = m.Height()
+					}
+					mq.Push(m)
+				}
+				Expect(mq.Peek()).To(Equal(minHeight))
+			})
+		})
+
+		It("should pop messages in height order", func() {
+			mq := replica.NewMessageQueue(100)
+			for i := 0; i < 100; i++ {
+				m := testutil.RandomMessageWithHeightAndRound(block.Height(i+1), block.Round(rand.Int63()), testutil.RandomMessageType(true))
+				mq.Push(m)
+			}
+			messages := mq.PopUntil(50)
+			Expect(messages).To(HaveLen(50))
+			Expect(messages[0].Height()).To(Equal(block.Height(1)))
+			Expect(messages[len(messages)-1].Height()).To(Equal(block.Height(50)))
+
+			for i := range messages {
+				if i < len(messages)-1 {
+					Expect(messages[i].Height() < messages[i+1].Height()).To(BeTrue())
+				}
+			}
+		})
+
+		It("should not insert the same message more than once", func() {
+			mq := replica.NewMessageQueue(100)
+			for i := 0; i < 100; i++ {
+				m := testutil.RandomMessageWithHeightAndRound(block.Height(i+1), block.Round(rand.Int63()), testutil.RandomMessageType(true))
+				mq.Push(m)
+				mq.Push(m)
+				mq.Push(m)
+			}
+			Expect(mq.Len()).To(Equal(100))
+		})
+
+		Context("when capacity is full", func() {
+			Context("when new messages are higher", func() {
+				It("should drop the biggest heights", func() {
+					mq := replica.NewMessageQueue(100)
+					// Insert too many messages.
+					for i := 0; i < 200; i++ {
+						m := testutil.RandomMessageWithHeightAndRound(block.Height(i+1), block.Round(rand.Int63()), testutil.RandomMessageType(true))
+						mq.Push(m)
+					}
+					// Expect the length to be equal to the initial capacity.
+					Expect(mq.Len()).To(Equal(100))
+
+					// Pop the first 50 messages and expect them to have the first
+					// 50 heights, indicating that the highest 100 messages were
+					// dropped.
+					messages := mq.PopUntil(50)
+					Expect(messages).To(HaveLen(50))
+					Expect(messages[0].Height()).To(Equal(block.Height(1)))
+					Expect(messages[len(messages)-1].Height()).To(Equal(block.Height(50)))
+
+					for i := range messages {
+						if i < len(messages)-1 {
+							Expect(messages[i].Height() < messages[i+1].Height()).To(BeTrue())
+						}
+					}
+				})
+			})
+
+			Context("when new messages are lower", func() {
+				It("should drop the biggest heights", func() {
+					mq := replica.NewMessageQueue(100)
+					// Insert too many messages.
+					for i := 200; i >= 0; i-- {
+						m := testutil.RandomMessageWithHeightAndRound(block.Height(i+1), block.Round(rand.Int63()), testutil.RandomMessageType(true))
+						mq.Push(m)
+					}
+					// Expect the length to be equal to the initial capacity.
+					Expect(mq.Len()).To(Equal(100))
+
+					// Pop the first 50 messages and expect them to have the first
+					// 50 heights, indicating that the highest 100 messages were
+					// dropped.
+					messages := mq.PopUntil(50)
+					Expect(messages).To(HaveLen(50))
+					Expect(messages[0].Height()).To(Equal(block.Height(1)))
+					Expect(messages[len(messages)-1].Height()).To(Equal(block.Height(50)))
+
+					for i := range messages {
+						if i < len(messages)-1 {
+							Expect(messages[i].Height() < messages[i+1].Height()).To(BeTrue())
+						}
+					}
+				})
+			})
+		})
+	})
+
+	Context("when peeking", func() {
+		Context("when the queue is empty", func() {
+			It("should return an invalid height", func() {
+				mq := replica.NewMessageQueue(100)
+				Expect(mq.Peek()).To(Equal(block.InvalidHeight))
+			})
 		})
 	})
 })

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -70,6 +70,10 @@ type Options struct {
 	BackOffExp  float64
 	BackOffBase time.Duration
 	BackOffMax  time.Duration
+
+	// MaxMessageQueueSize is the maximum number of "future" messages that the
+	// Replica will buffer in memory.
+	MaxMessageQueueSize int
 }
 
 func (options *Options) setZerosToDefaults() {
@@ -84,6 +88,9 @@ func (options *Options) setZerosToDefaults() {
 	}
 	if options.BackOffMax == time.Duration(0) {
 		options.BackOffMax = 5 * time.Minute
+	}
+	if options.MaxMessageQueueSize == 0 {
+		options.MaxMessageQueueSize = 512
 	}
 }
 
@@ -102,7 +109,7 @@ type Replica struct {
 	rebaser   *shardRebaser
 	cache     baseBlockCache
 
-	messagesSinceLastSave int
+	messageQueue MessageQueue
 }
 
 func New(options Options, pStorage ProcessStorage, blockStorage BlockStorage, blockIterator BlockIterator, validator Validator, observer Observer, broadcaster Broadcaster, shard Shard, privKey ecdsa.PrivateKey) Replica {
@@ -140,7 +147,7 @@ func New(options Options, pStorage ProcessStorage, blockStorage BlockStorage, bl
 		rebaser:   shardRebaser,
 		cache:     newBaseBlockCache(latestBase),
 
-		messagesSinceLastSave: 0,
+		messageQueue: NewMessageQueue(options.MaxMessageQueueSize),
 	}
 }
 
@@ -149,6 +156,13 @@ func (replica *Replica) Start() {
 }
 
 func (replica *Replica) HandleMessage(m Message) {
+	// Check that Message is from our shard. If it is not, then there is no
+	// point processing the message.
+	if !replica.shard.Equal(m.Shard) {
+		replica.options.Logger.Warnf("bad message: expected shard=%v, got shard=%v", replica.shard, m.Shard)
+		return
+	}
+
 	// Ignore messagse from heights that the process has already progressed
 	// through. Messages at these earlier heights have no affect on consensus,
 	// and so there is no point wasting time processing them.
@@ -159,13 +173,6 @@ func (replica *Replica) HandleMessage(m Message) {
 		}
 	}
 
-	// Check that Message is from our shard. If it is not, then there is no
-	// point processing the message.
-	if !replica.shard.Equal(m.Shard) {
-		replica.options.Logger.Warnf("bad message: expected shard=%v, got shard=%v", replica.shard, m.Shard)
-		return
-	}
-
 	// Check that the Message sender is from our Shard (this can be a moderately
 	// expensive operation, so we cache the result until a new `block.Base` is
 	// detected)
@@ -173,17 +180,34 @@ func (replica *Replica) HandleMessage(m Message) {
 	if !replica.cache.signatoryInBaseBlock(m.Message.Signatory()) {
 		return
 	}
-
 	// Verify that the Message is actually signed by the claimed `id.Signatory`
 	if err := process.Verify(m.Message); err != nil {
 		replica.options.Logger.Warnf("bad message: unverified: %v", err)
 		return
 	}
 
-	// Handle the underlying `process.Message` and immediately save the
-	// `process.Process` afterwards to protect against unexpected crashes
-	replica.p.HandleMessage(m.Message)
-	replica.p.Save()
+	// Messages from future heights are buffered.
+	if m.Message.Height() > replica.p.CurrentHeight() && m.Message.Type() != process.ProposeMessageType {
+		// We only want to buffer non-Propose messages, because Propose messages
+		// can have a LatestCommit message to fast-forward the process.
+		replica.messageQueue.Push(m.Message)
+	} else {
+		// Handle the underlying `process.Message` and immediately save the
+		// `process.Process` afterwards to protect against unexpected crashes
+		replica.p.HandleMessage(m.Message)
+	}
+	defer replica.p.Save()
+
+	queued := replica.messageQueue.PopUntil(replica.p.CurrentHeight())
+	for queued != nil && len(queued) > 0 {
+		for _, message := range queued {
+			// Handle the underlying `process.Message` and immediately save the
+			// `process.Process` afterwards to protect against unexpected
+			// crashes
+			replica.p.HandleMessage(message)
+		}
+		queued = replica.messageQueue.PopUntil(replica.p.CurrentHeight())
+	}
 }
 
 func (replica *Replica) Rebase(sigs id.Signatories) {


### PR DESCRIPTION
This PR fixes #49 by implementing the `MessageQueue` interface. This interface stores all message that are higher than the current height, other than Propose messages (because these messages can cause fast-forwarding).