### PR TITLE
Protect against Resync replay attacks

### DIFF
--- a/process/marshal.go
+++ b/process/marshal.go
@@ -181,7 +181,8 @@ func (resync Resync) SizeHint() int {
 	return surge.SizeHint(resync.signatory) +
 		surge.SizeHint(resync.sig) +
 		surge.SizeHint(resync.height) +
-		surge.SizeHint(resync.round)
+		surge.SizeHint(resync.round) +
+		surge.SizeHint(resync.timestamp)
 }
 
 // Marshal this resync into binary.
@@ -196,7 +197,10 @@ func (resync Resync) Marshal(w io.Writer, m int) (int, error) {
 	if m, err = surge.Marshal(w, resync.height, m); err != nil {
 		return m, err
 	}
-	return surge.Marshal(w, resync.round, m)
+	if m, err = surge.Marshal(w, resync.round, m); err != nil {
+		return m, err
+	}
+	return surge.Marshal(w, resync.timestamp, m)
 }
 
 // Unmarshal into this resync from binary.
@@ -211,7 +215,10 @@ func (resync *Resync) Unmarshal(r io.Reader, m int) (int, error) {
 	if m, err = surge.Unmarshal(r, &resync.height, m); err != nil {
 		return m, err
 	}
-	return surge.Unmarshal(r, &resync.round, m)
+	if m, err = surge.Unmarshal(r, &resync.round, m); err != nil {
+		return m, err
+	}
+	return surge.Unmarshal(r, &resync.timestamp, m)
 }
 
 // SizeHint of how many bytes will be needed to represent this inbox in binary.

--- a/process/message.go
+++ b/process/message.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/renproject/hyperdrive/block"
@@ -345,12 +346,14 @@ type Resync struct {
 	sig       id.Signature
 	height    block.Height
 	round     block.Round
+	timestamp block.Timestamp
 }
 
 func NewResync(height block.Height, round block.Round) *Resync {
 	return &Resync{
-		height: height,
-		round:  round,
+		height:    height,
+		round:     round,
+		timestamp: block.Timestamp(time.Now().Unix()),
 	}
 }
 
@@ -374,6 +377,10 @@ func (resync *Resync) Round() block.Round {
 	return resync.round
 }
 
+func (resync *Resync) Timestamp() block.Timestamp {
+	return resync.timestamp
+}
+
 func (resync *Resync) BlockHash() id.Hash {
 	panic(ErrBlockHashNotProvided)
 }
@@ -383,7 +390,7 @@ func (resync *Resync) Type() MessageType {
 }
 
 func (resync *Resync) String() string {
-	return fmt.Sprintf("Resync(Height=%v,Round=%v)", resync.Height(), resync.Round())
+	return fmt.Sprintf("Resync(Height=%v,Round=%v,Timestamp=%v)", resync.Height(), resync.Round(), resync.Timestamp())
 }
 
 // An Inbox is storage container for one type message. Any type of message can

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -158,6 +158,28 @@ func (replica *Replica) HandleMessage(m Message) {
 			return
 		}
 	}
+	if m.Message.Type() == process.ResyncMessageType {
+		if m.Message.Height() > replica.p.CurrentHeight() {
+			// We cannot respond to resync messages from future heights with
+			// anything that is useful, so we ignore it.
+			replica.options.Logger.Debugf("ignore message: resync height=%v compared to current height=%v", m.Message.Height(), replica.p.CurrentHeight())
+			return
+		}
+		// Filter resync messages by timestamp. If they're too old, or too far
+		// in the future, then ignore them. The total window of time is 20
+		// seconds, approximately the latency expected for globally distributed
+		// message passing.
+		now := block.Timestamp(time.Now().Unix())
+		timestamp := m.Message.(*process.Resync).Timestamp()
+		if now < timestamp-10 {
+			replica.options.Logger.Debugf("ignore message: resync timestamp=%v compared to now=%v", timestamp, now)
+			return
+		}
+		if now > timestamp+10 {
+			replica.options.Logger.Debugf("ignore message: resync timestamp=%v compared to now=%v", timestamp, now)
+			return
+		}
+	}
 
 	// Check that Message is from our shard. If it is not, then there is no
 	// point processing the message.

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -171,11 +171,11 @@ func (replica *Replica) HandleMessage(m Message) {
 		// message passing.
 		now := block.Timestamp(time.Now().Unix())
 		timestamp := m.Message.(*process.Resync).Timestamp()
-		if now < timestamp-10 {
-			replica.options.Logger.Debugf("ignore message: resync timestamp=%v compared to now=%v", timestamp, now)
-			return
+		delta := now - timestamp
+		if delta < 0 {
+			delta = -delta
 		}
-		if now > timestamp+10 {
+		if delta > 10 {
 			replica.options.Logger.Debugf("ignore message: resync timestamp=%v compared to now=%v", timestamp, now)
 			return
 		}


### PR DESCRIPTION
This PR fixes #50 by introducing timestamps to Resync messages, and ignoring Resync messages that have timestamps outside of a reasonable range. More advanced protections have been deferred to #72.