### PR TITLE
Bad behaviour catcher

### DIFF
--- a/hyperdrive.go
+++ b/hyperdrive.go
@@ -145,7 +145,7 @@ func New(options Options, pStorage ProcessStorage, blockStorage BlockStorage, bl
 	for _, shard := range shards {
 		if observer.IsSignatory(shard) {
 			rr := schedule.RoundRobin(blockStorage.LatestBaseBlock(shard).Header().Signatories())
-			replicas[shard] = replica.New(options, pStorage, blockStorage, blockIterator, validator, observer, broadcaster, rr, shard, privKey)
+			replicas[shard] = replica.New(options, pStorage, blockStorage, blockIterator, validator, observer, broadcaster, rr, process.CatchAndIgnore(), shard, privKey)
 		}
 	}
 	return &hyperdrive{

--- a/process/catch.go
+++ b/process/catch.go
@@ -1,0 +1,28 @@
+package process
+
+// A Catcher is used to publish events about potential malicious behaviour by
+// other Processes.
+type Catcher interface {
+	// DidReceiveMessageConflict is called when a new Message is received that
+	// conflicts with an existing Message. Messages of the same type are defined
+	// to be in conflict when they are from the same Signatory, Height, and
+	// Round, but have different contents.
+	//
+	// For example, when proposing a Block in any given Height and Round, an
+	// honest Process should only ever propose one Block. A malicious Process
+	// might try to break consensus by proposing two different Blocks, resulting
+	// in two conflicting Proposes in the same Height and Round.
+	DidReceiveMessageConflict(original, conflicting Message)
+}
+
+type catchAndIgnore struct{}
+
+// CatchAndIgnore returns a Catcher that ignores all potentiall malicious
+// behaviour. It should only be used during testing, or when Processes are known
+// to be honest.
+func CatchAndIgnore() Catcher {
+	return catchAndIgnore{}
+}
+
+// DidReceiveMessageConflict does nothing.
+func (catchAndIgnore) DidReceiveMessageConflict(original, conflicting Message) {}

--- a/process/catch.go
+++ b/process/catch.go
@@ -12,7 +12,7 @@ type Catcher interface {
 	// honest Process should only ever propose one Block. A malicious Process
 	// might try to break consensus by proposing two different Blocks, resulting
 	// in two conflicting Proposes in the same Height and Round.
-	DidReceiveMessageConflict(original, conflicting Message)
+	DidReceiveMessageConflict(conflicting, message Message)
 }
 
 type catchAndIgnore struct{}
@@ -25,4 +25,4 @@ func CatchAndIgnore() Catcher {
 }
 
 // DidReceiveMessageConflict does nothing.
-func (catchAndIgnore) DidReceiveMessageConflict(original, conflicting Message) {}
+func (catchAndIgnore) DidReceiveMessageConflict(conflicting, message Message) {}

--- a/process/catch_test.go
+++ b/process/catch_test.go
@@ -1,0 +1,1 @@
+package process_test

--- a/process/message_test.go
+++ b/process/message_test.go
@@ -407,7 +407,7 @@ var _ = Describe("Messages", func() {
 					f := rand.Intn(100) + 1
 					messageType := RandomMessageType(false)
 					inbox := NewInbox(f, messageType)
-					n, firstTime, firstTimeExceedingF, firstTimeExceeding2F, _ := inbox.Insert(RandomMessage(messageType))
+					n, firstTime, firstTimeExceedingF, firstTimeExceeding2F, _, _ := inbox.Insert(RandomMessage(messageType))
 					Expect(n).Should(Equal(1))
 					Expect(firstTime).Should(BeTrue())
 					Expect(firstTimeExceedingF).Should(BeFalse())
@@ -429,7 +429,7 @@ var _ = Describe("Messages", func() {
 					// Expect n, false, false, false when inserting no more than F messages
 					for i := 1; i <= f; i++ {
 						msg := RandomSingedMessageWithHeightAndRound(height, round, messageType)
-						n, firstTime, firstTimeExceedingF, firstTimeExceeding2F, _ := inbox.Insert(msg)
+						n, firstTime, firstTimeExceedingF, firstTimeExceeding2F, _, _ := inbox.Insert(msg)
 						Expect(n).Should(Equal(i))
 						if i == 1 {
 							Expect(firstTime).Should(BeTrue())
@@ -442,7 +442,7 @@ var _ = Describe("Messages", func() {
 
 					// Expect F+1, false, true, false when inserting F+1 message
 					msg := RandomSingedMessageWithHeightAndRound(height, round, messageType)
-					n, firstTime, firstTimeExceedingF, firstTimeExceeding2F, _ := inbox.Insert(msg)
+					n, firstTime, firstTimeExceedingF, firstTimeExceeding2F, _, _ := inbox.Insert(msg)
 
 					Expect(n).Should(Equal(f + 1))
 					Expect(firstTime).Should(BeFalse())
@@ -465,14 +465,14 @@ var _ = Describe("Messages", func() {
 					// Expect n, false, false,false when inserting no more than F messages
 					for i := 1; i <= 2*f; i++ {
 						msg := RandomSingedMessageWithHeightAndRound(height, round, messageType)
-						n, _, _, firstTimeExceeding2F, _ := inbox.Insert(msg)
+						n, _, _, firstTimeExceeding2F, _, _ := inbox.Insert(msg)
 						Expect(n).Should(Equal(i))
 						Expect(firstTimeExceeding2F).Should(BeFalse())
 					}
 
 					// Expect 2F+1, false, true, false when inserting F+1 message
 					msg := RandomSingedMessageWithHeightAndRound(height, round, messageType)
-					n, firstTime, firstTimeExceedingF, firstTimeExceeding2F, _ := inbox.Insert(msg)
+					n, firstTime, firstTimeExceedingF, firstTimeExceeding2F, _, _ := inbox.Insert(msg)
 
 					Expect(n).Should(Equal(2*f + 1))
 					Expect(firstTime).Should(BeFalse())
@@ -495,14 +495,14 @@ var _ = Describe("Messages", func() {
 					// Expect n, false, false,false when inserting no more than F messages
 					for i := 1; i <= 2*f+1; i++ {
 						msg := RandomSingedMessageWithHeightAndRound(height, round, messageType)
-						n, _, _, _, _ := inbox.Insert(msg)
+						n, _, _, _, _, _ := inbox.Insert(msg)
 						Expect(n).Should(Equal(i))
 					}
 
 					// Expect 3F+1, false, true, false when inserting F+1 message
 					for i := 1; i < rand.Intn(100); i++ {
 						msg := RandomSingedMessageWithHeightAndRound(height, round, messageType)
-						n, firstTime, firstTimeExceedingF, firstTimeExceeding2F, _ := inbox.Insert(msg)
+						n, firstTime, firstTimeExceedingF, firstTimeExceeding2F, _, _ := inbox.Insert(msg)
 
 						Expect(n).Should(Equal(2*f + 1 + i))
 						Expect(firstTime).Should(BeFalse())
@@ -528,8 +528,8 @@ var _ = Describe("Messages", func() {
 						msg := RandomSignedMessage(messageType)
 
 						// Inserting the same msg twice should not affect anything
-						_, _, _, _, _ = inbox.Insert(msg)
-						_, _, _, _, _ = inbox.Insert(msg)
+						_, _, _, _, _, _ = inbox.Insert(msg)
+						_, _, _, _, _, _ = inbox.Insert(msg)
 
 						if _, ok := source[msg.Height()]; !ok {
 							source[msg.Height()] = map[block.Round]map[id.Hash]int{}
@@ -570,8 +570,8 @@ var _ = Describe("Messages", func() {
 						Expect(nilMessage).Should(BeNil())
 
 						// Inserting the same msg twice should not affect anything
-						_, _, _, _, _ = inbox.Insert(msg)
-						_, _, _, _, _ = inbox.Insert(msg)
+						_, _, _, _, _, _ = inbox.Insert(msg)
+						_, _, _, _, _, _ = inbox.Insert(msg)
 
 						// It return the same message we inserted
 						storedMsg := inbox.QueryByHeightRoundSignatory(msg.Height(), msg.Round(), msg.Signatory())
@@ -596,8 +596,8 @@ var _ = Describe("Messages", func() {
 						msg := RandomSignedMessage(messageType)
 
 						// Inserting the same msg twice should not affect anything
-						_, _, _, _, _ = inbox.Insert(msg)
-						_, _, _, _, _ = inbox.Insert(msg)
+						_, _, _, _, _, _ = inbox.Insert(msg)
+						_, _, _, _, _, _ = inbox.Insert(msg)
 
 						if _, ok := source[msg.Height()]; !ok {
 							source[msg.Height()] = map[block.Round]int{}

--- a/process/process.go
+++ b/process/process.go
@@ -127,10 +127,11 @@ type Process struct {
 	broadcaster  Broadcaster
 	timer        Timer
 	observer     Observer
+	catcher      Catcher
 }
 
 // New Process initialised to the default state, starting in the first round.
-func New(logger logrus.FieldLogger, signatory id.Signatory, blockchain Blockchain, state State, saveRestorer SaveRestorer, proposer Proposer, validator Validator, observer Observer, broadcaster Broadcaster, scheduler schedule.Scheduler, timer Timer) *Process {
+func New(logger logrus.FieldLogger, signatory id.Signatory, blockchain Blockchain, state State, saveRestorer SaveRestorer, proposer Proposer, validator Validator, observer Observer, broadcaster Broadcaster, scheduler schedule.Scheduler, timer Timer, catcher Catcher) *Process {
 	p := &Process{
 		logger: logger,
 		mu:     new(sync.Mutex),
@@ -142,10 +143,11 @@ func New(logger logrus.FieldLogger, signatory id.Signatory, blockchain Blockchai
 		saveRestorer: saveRestorer,
 		proposer:     proposer,
 		validator:    validator,
-		observer:     observer,
-		broadcaster:  broadcaster,
 		scheduler:    scheduler,
+		broadcaster:  broadcaster,
 		timer:        timer,
+		observer:     observer,
+		catcher:      catcher,
 	}
 	return p
 }

--- a/process/process.go
+++ b/process/process.go
@@ -361,9 +361,13 @@ func (p *Process) handlePropose(propose *Propose) {
 	// Before inserting the Propose, we need to check whether or not the Propose
 	// is from the scheduled Proposer. Otherwise, we can safely ignore it.
 	var firstTime bool
+	var conflicting Message
 	if propose.Signatory().Equal(p.scheduler.Schedule(propose.Height(), propose.Round())) {
 		p.logger.Debugf("received propose at height=%v and round=%v", propose.height, propose.round)
-		_, firstTime, _, _, _ = p.state.Proposals.Insert(propose)
+		_, firstTime, _, _, _, conflicting = p.state.Proposals.Insert(propose)
+		if conflicting != nil && p.catcher != nil {
+			p.catcher.DidReceiveMessageConflict(conflicting, propose)
+		}
 	} else {
 		// Ignore out-of-turn Proposes.
 		p.logger.Warnf("received propose at height=%v and round=%v from out-of-turn proposer=%v", propose.height, propose.round, propose.signatory)
@@ -441,7 +445,10 @@ func (p *Process) handlePrevote(prevote *Prevote) {
 		prevoteDebugStr = prevote.blockHash.String()
 	}
 	p.logger.Debugf("received prevote=%v at height=%v and round=%v", prevoteDebugStr, prevote.height, prevote.round)
-	_, _, _, firstTimeExceeding2F, firstTimeExceeding2FOnBlockHash := p.state.Prevotes.Insert(prevote)
+	_, _, _, firstTimeExceeding2F, firstTimeExceeding2FOnBlockHash, conflicting := p.state.Prevotes.Insert(prevote)
+	if conflicting != nil && p.catcher != nil {
+		p.catcher.DidReceiveMessageConflict(conflicting, prevote)
+	}
 	if firstTimeExceeding2F && prevote.Height() == p.state.CurrentHeight && prevote.Round() == p.state.CurrentRound && p.state.CurrentStep == StepPrevote {
 		// upon 2f+1 Prevote{currentHeight, currentRound, *} while step = StepPrevote for the first time
 		p.scheduleTimeoutPrevote(p.state.CurrentHeight, p.state.CurrentRound, p.timer.Timeout(StepPrevote, p.state.CurrentRound))
@@ -491,7 +498,10 @@ func (p *Process) handlePrecommit(precommit *Precommit) {
 	}
 	p.logger.Debugf("received precommit=%v at height=%v and round=%v", precommitDebugStr, precommit.height, precommit.round)
 	// upon 2f+1 Precommit{currentHeight, currentRound, *} for the first time
-	_, _, _, firstTimeExceeding2F, _ := p.state.Precommits.Insert(precommit)
+	_, _, _, firstTimeExceeding2F, _, conflicting := p.state.Precommits.Insert(precommit)
+	if conflicting != nil && p.catcher != nil {
+		p.catcher.DidReceiveMessageConflict(conflicting, precommit)
+	}
 	if firstTimeExceeding2F && precommit.Height() == p.state.CurrentHeight && precommit.Round() == p.state.CurrentRound {
 		p.scheduleTimeoutPrecommit(p.state.CurrentHeight, p.state.CurrentRound, p.timer.Timeout(StepPrecommit, p.state.CurrentRound))
 	}

--- a/replica/rebase.go
+++ b/replica/rebase.go
@@ -154,13 +154,19 @@ func (rebaser *shardRebaser) IsBlockValid(proposedBlock block.Block, checkHistor
 
 	// Check the expected `block.Hash`
 	if !proposedBlock.Header().TxsRef().Equal(proposedBlock.Txs().Hash()) {
-		return nilReasons, fmt.Errorf("unexpected txs hash for proposed block")
+		if !(proposedBlock.Txs() == nil && proposedBlock.Header().TxsRef().Equal(id.Hash{})) {
+			return nilReasons, fmt.Errorf("unexpected txs hash for proposed block")
+		}
 	}
 	if !proposedBlock.Header().PlanRef().Equal(proposedBlock.Plan().Hash()) {
-		return nilReasons, fmt.Errorf("unexpected plan hash for proposed block")
+		if !(proposedBlock.Plan() == nil && proposedBlock.Header().PlanRef().Equal(id.Hash{})) {
+			return nilReasons, fmt.Errorf("unexpected plan hash for proposed block")
+		}
 	}
 	if !proposedBlock.Header().PrevStateRef().Equal(proposedBlock.PreviousState().Hash()) {
-		return nilReasons, fmt.Errorf("unexpected plan hash for proposed block")
+		if !(proposedBlock.PreviousState() == nil && proposedBlock.Header().PrevStateRef().Equal(id.Hash{})) {
+			return nilReasons, fmt.Errorf("unexpected previous state hash for proposed block")
+		}
 	}
 	if !proposedBlock.Hash().Equal(block.NewBlockHash(proposedBlock.Header(), proposedBlock.Txs(), proposedBlock.Plan(), proposedBlock.PreviousState())) {
 		return nilReasons, fmt.Errorf("unexpected block hash for proposed block")

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -113,7 +113,7 @@ type Replica struct {
 	messageQueue MessageQueue
 }
 
-func New(options Options, pStorage ProcessStorage, blockStorage BlockStorage, blockIterator BlockIterator, validator Validator, observer Observer, broadcaster Broadcaster, scheduler schedule.Scheduler, shard Shard, privKey ecdsa.PrivateKey) Replica {
+func New(options Options, pStorage ProcessStorage, blockStorage BlockStorage, blockIterator BlockIterator, validator Validator, observer Observer, broadcaster Broadcaster, scheduler schedule.Scheduler, catcher process.Catcher, shard Shard, privKey ecdsa.PrivateKey) Replica {
 	options.setZerosToDefaults()
 	latestBase := blockStorage.LatestBaseBlock(shard)
 	if len(latestBase.Header().Signatories())%3 != 1 || len(latestBase.Header().Signatories()) < 4 {
@@ -134,6 +134,7 @@ func New(options Options, pStorage ProcessStorage, blockStorage BlockStorage, bl
 		newSigner(broadcaster, shard, privKey),
 		scheduler,
 		newBackOffTimer(options.BackOffExp, options.BackOffBase, options.BackOffMax),
+		catcher,
 	)
 	p.Restore()
 

--- a/replica/replica_test.go
+++ b/replica/replica_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Replica", func() {
 					pstore := mockProcessStorage{}
 					broadcaster, _, _ := newMockBroadcaster()
 					scheduler := schedule.RoundRobin(store.LatestBaseBlock(shard).Header().Signatories())
-					replica := New(Options{}, pstore, store, mockBlockIterator{}, nil, nil, broadcaster, scheduler, shard, *newEcdsaKey())
+					replica := New(Options{}, pstore, store, mockBlockIterator{}, nil, nil, broadcaster, scheduler, process.CatchAndIgnore(), shard, *newEcdsaKey())
 
 					pMessage := RandomMessage(process.ProposeMessageType)
 					numStored := 0
@@ -110,7 +110,7 @@ var _ = Describe("Replica", func() {
 					pstore := mockProcessStorage{}
 					broadcaster, _, _ := newMockBroadcaster()
 					scheduler := schedule.RoundRobin(store.LatestBaseBlock(shard).Header().Signatories())
-					replica := New(Options{}, pstore, store, mockBlockIterator{}, nil, nil, broadcaster, scheduler, shard, *newEcdsaKey())
+					replica := New(Options{}, pstore, store, mockBlockIterator{}, nil, nil, broadcaster, scheduler, process.CatchAndIgnore(), shard, *newEcdsaKey())
 					logger := logrus.StandardLogger()
 					logger.SetOutput(ioutil.Discard)
 					replica.options.Logger = logger
@@ -140,7 +140,7 @@ var _ = Describe("Replica", func() {
 					pstore := mockProcessStorage{}
 					broadcaster, _, _ := newMockBroadcaster()
 					scheduler := schedule.RoundRobin(store.LatestBaseBlock(shard).Header().Signatories())
-					replica := New(Options{}, pstore, store, mockBlockIterator{}, nil, nil, broadcaster, scheduler, shard, *newEcdsaKey())
+					replica := New(Options{}, pstore, store, mockBlockIterator{}, nil, nil, broadcaster, scheduler, process.CatchAndIgnore(), shard, *newEcdsaKey())
 
 					pMessage := RandomSignedMessage(process.ProposeMessageType)
 					message := Message{

--- a/testutil/process.go
+++ b/testutil/process.go
@@ -233,6 +233,7 @@ func (p ProcessOrigin) ToProcess() *process.Process {
 		p.Broadcaster,
 		p.Scheduler,
 		p.Timer,
+		process.CatchAndIgnore(),
 	)
 }
 


### PR DESCRIPTION
This PR fixes #48 by introducing the `Catcher` interface. It is called whenever the `Process` receives a message that conflicts with an existing message. Two messages are said to be conflicting when they are of the same type, are from the same signatory, height, and round, but have different contents.