### PR TITLE
Fix using bad base block

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -49,6 +49,7 @@ type Blockchain interface {
 	InsertBlockAtHeight(block.Height, block.Block)
 	BlockAtHeight(block.Height) (block.Block, bool)
 	BlockExistsAtHeight(block.Height) bool
+	LatestBaseBlock() block.Block
 }
 
 // A SaveRestorer defines a storage interface for the State.
@@ -756,10 +757,7 @@ func (p *Process) syncLatestCommit(latestCommit LatestCommit) {
 
 	// Validate the commits
 	signatories := map[id.Signatory]struct{}{}
-	baseBlock, ok := p.blockchain.BlockAtHeight(0)
-	if !ok {
-		panic("no genesis block")
-	}
+	baseBlock := p.blockchain.LatestBaseBlock()
 	for _, sig := range baseBlock.Header().Signatories() {
 		signatories[sig] = struct{}{}
 	}

--- a/replica/rebase.go
+++ b/replica/rebase.go
@@ -23,6 +23,11 @@ type BlockIterator interface {
 	// NextBlock returns the `block.Txs`, `block.Plan` and the parent
 	// `block.State` for the given `block.Height`.
 	NextBlock(block.Kind, block.Height, Shard) (block.Txs, block.Plan, block.State)
+
+	// BaseBlocksInRange must return an upper bound estimate for the number of
+	// base blocks between two blocks (identified by their block hash). This is
+	// used to prevent forking by old signatories.
+	BaseBlocksInRange(begin, end id.Hash) int
 }
 
 type Validator interface {

--- a/replica/replica_suite_test.go
+++ b/replica/replica_suite_test.go
@@ -75,6 +75,10 @@ func (m mockBlockIterator) NextBlock(kind block.Kind, height block.Height, shard
 	return RandomBytesSlice(), RandomBytesSlice(), RandomBytesSlice()
 }
 
+func (m mockBlockIterator) BaseBlocksInRange(begin, end id.Hash) int {
+	return 0 // mockBlockIterator does not support rebasing.
+}
+
 type mockValidator struct {
 	valid error
 }

--- a/testutil/process.go
+++ b/testutil/process.go
@@ -281,6 +281,17 @@ func (bc *MockBlockchain) BlockAtHeight(height block.Height) (block.Block, bool)
 	return block, ok
 }
 
+func (bc *MockBlockchain) LatestBaseBlock() block.Block {
+	bc.mu.RLock()
+	defer bc.mu.RUnlock()
+
+	block, ok := bc.blocks[0]
+	if !ok {
+		panic("no genesis block")
+	}
+	return block
+}
+
 func (bc *MockBlockchain) StateAtHeight(height block.Height) (block.State, bool) {
 	bc.mu.RLock()
 	defer bc.mu.RUnlock()

--- a/testutil/replica/replica.go
+++ b/testutil/replica/replica.go
@@ -78,6 +78,10 @@ func (m *MockBlockIterator) NextBlock(kind block.Kind, height block.Height, shar
 	}
 }
 
+func (m *MockBlockIterator) BaseBlocksInRange(begin, end id.Hash) int {
+	return 0 // MockBlockIterator does not support rebasing.
+}
+
 type MockValidator struct {
 	store *MockPersistentStorage
 }


### PR DESCRIPTION
This PR fixes #51 by introducing the `Rebase.BaseBlocksInRange(begin, end Hash) int` in combination with adding `Blockchain.LatestBaseBlock`. One notable difference from #51 is that we do not do explicit block resynchronisation.

The network assumptions of Tendermint (and therefore Hyperdrive), is that all messages are eventually delivered. This means that we do not need to explicitly resync, because all `Proposes` will eventually be seen and base blocks will be accepted as part of this. This is a less efficient approach then explicit resynchronisation, so an issue for this has been created and will be implemented in the next release (see #77). It is not implemented for now, because we will be doing an overall review of all data synchronisation to reduce memory allocations and network bandwidth.