### PR TITLE
Check missing base blocks for messages read off the queue

### DIFF
--- a/replica/replica.go
+++ b/replica/replica.go
@@ -247,15 +247,24 @@ func (replica *Replica) HandleMessage(m Message) {
 
 	queued := replica.messageQueue.PopUntil(replica.p.CurrentHeight())
 	for queued != nil && len(queued) > 0 {
+		baseBlockHash := replica.blockStorage.LatestBaseBlock(m.Shard).Hash()
 		for _, message := range queued {
-			// Handle the Message. After all Messages that can be handled have
-			// been handled, this function will end, and the Process will be
-			// saved. This protects the Process from crashing part way through
-			// handling a Message and ending up in a partially saved State
-			// caused by "saving on the go". We could save between each message,
-			// but this would have a large performance footprint (and is
-			// ultimately unnecessary, because we do not expect crashes).
-			replica.p.HandleMessage(message)
+			// We need to make sure that no base blocks have been missed while
+			// the message was sitting on the queue. If we have missed a base
+			// block, we drop the message.
+			blockHash := message.BlockHash()
+			numMissingBaseBlocks := replica.rebaser.blockIterator.BaseBlocksInRange(baseBlockHash, blockHash)
+			if numMissingBaseBlocks == 0 {
+				// Otherwise, we handle the Message. After all Messages that can
+				// be handled have been handled, this function will end, and the
+				// Process will be saved. This protects the Process from
+				// crashing part way through handling a Message and ending up in
+				// a partially saved State caused by "saving on the go". We
+				// could save between each message, but this would have a large
+				// performance footprint (and is ultimately unnecessary, because
+				// we do not expect crashes).
+				replica.p.HandleMessage(message)
+			}
 		}
 		queued = replica.messageQueue.PopUntil(replica.p.CurrentHeight())
 	}


### PR DESCRIPTION
Previously, `Precommit` and `Prevote` messages that made it into the queue were being processed even if there was a base block that changed the set of signatories. This PR adds an additional check to the `replica.HandleMessage` function for missing base blocks when reading messages off the queue.