### PR TITLE
Fix handling of Resync messages

### DIFF
--- a/replica/replica.go
+++ b/replica/replica.go
@@ -191,6 +191,9 @@ func (replica *Replica) HandleMessage(m Message) {
 	// Make sure that the Process state gets saved.
 	defer replica.p.Save()
 
+	// Resync messages can be handled immediately, as long as they are not from
+	// a future height and their timestamps do not differ greatly from the
+	// current time.
 	if m.Message.Type() == process.ResyncMessageType {
 		if m.Message.Height() > replica.p.CurrentHeight() {
 			// We cannot respond to resync messages from future heights with
@@ -198,7 +201,7 @@ func (replica *Replica) HandleMessage(m Message) {
 			replica.options.Logger.Debugf("ignore message: resync height=%v compared to current height=%v", m.Message.Height(), replica.p.CurrentHeight())
 			return
 		}
-		// Filter resync messages by timestamp. If they're too old, or too far
+		// Filter Resync messages by timestamp. If they're too old, or too far
 		// in the future, then ignore them. The total window of time is 20
 		// seconds, approximately the latency expected for globally distributed
 		// message passing.

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -214,6 +214,7 @@ func (replica *Replica) HandleMessage(m Message) {
 			return
 		}
 		replica.p.HandleMessage(m.Message)
+		return
 	}
 	
 	// Make sure that the Process state gets saved. We do this here

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -188,8 +188,6 @@ func (replica *Replica) HandleMessage(m Message) {
 		return
 	}
 
-	// Make sure that the Process state gets saved.
-	defer replica.p.Save()
 
 	// Resync messages can be handled immediately, as long as they are not from
 	// a future height and their timestamps do not differ greatly from the

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -217,6 +217,11 @@ func (replica *Replica) HandleMessage(m Message) {
 		}
 		replica.p.HandleMessage(m.Message)
 	}
+	
+	// Make sure that the Process state gets saved. We do this here
+	// because Resync cannot cause state changes, so there is no
+	// reason to save after handling a Resync message.
+	defer replica.p.Save()
 
 	// Messages from the current height can be handled immediately.
 	if m.Message.Height() == replica.p.CurrentHeight() {


### PR DESCRIPTION
The introduction of the message queue (#71) required some changes to the implementation of `HandleMessage()` inside the replica. This introduced an issue with the handling of Resync messages, specifically, they were being dropped entirely. This PR adds a missing call to `replica.p.HandleMessage(m.Message)` at the end of the Resync conditional, and reorganises some of the code to perform some verification checks prior to handling Resync messages.