### PR TITLE
Rename "BaseBlocksInRange" function and improve documentation

### DIFF
--- a/replica/rebase.go
+++ b/replica/rebase.go
@@ -29,7 +29,10 @@ type BlockIterator interface {
 	// by their block hash). This is used to prevent forking by old signatories.
 	// This function should not include the "end" block as a missed block if it
 	// is a rebasing Propose as if this function is being called, it has clearly
-	// not been missed.
+	// not been missed. For example, if the range is heights 10 - 20 and there
+	// was expected to be a base block at 18, then this function is expected to
+	// return 1. However, if there was expected to be a block at height 20,
+	// then this function would return 0.
 	MissedBaseBlocksInRange(begin, end id.Hash) int
 }
 

--- a/replica/rebase.go
+++ b/replica/rebase.go
@@ -24,10 +24,13 @@ type BlockIterator interface {
 	// `block.State` for the given `block.Height`.
 	NextBlock(block.Kind, block.Height, Shard) (block.Txs, block.Plan, block.State)
 
-	// BaseBlocksInRange must return an upper bound estimate for the number of
-	// base blocks between two blocks (identified by their block hash). This is
-	// used to prevent forking by old signatories.
-	BaseBlocksInRange(begin, end id.Hash) int
+	// MissedBaseBlocksInRange must return an upper bound estimate for the
+	// number of missed base blocks between (exclusive) two blocks (identified
+	// by their block hash). This is used to prevent forking by old signatories.
+	// This function should not include the "end" block as a missed block if it
+	// is a rebasing Propose as if this function is being called, it has clearly
+	// not been missed.
+	MissedBaseBlocksInRange(begin, end id.Hash) int
 }
 
 type Validator interface {

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -253,7 +253,7 @@ func (replica *Replica) HandleMessage(m Message) {
 			// the message was sitting on the queue. If we have missed a base
 			// block, we drop the message.
 			blockHash := message.BlockHash()
-			numMissingBaseBlocks := replica.rebaser.blockIterator.BaseBlocksInRange(baseBlockHash, blockHash)
+			numMissingBaseBlocks := replica.rebaser.blockIterator.MissedBaseBlocksInRange(baseBlockHash, blockHash)
 			if numMissingBaseBlocks == 0 {
 				// Otherwise, we handle the Message. After all Messages that can
 				// be handled have been handled, this function will end, and the

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -231,7 +231,7 @@ func (replica *Replica) HandleMessage(m Message) {
 			// Propose, and wait until the appropriate one has been seen.
 			baseBlockHash := replica.blockStorage.LatestBaseBlock(m.Shard).Hash()
 			blockHash := m.Message.BlockHash()
-			numMissingBaseBlocks := replica.rebaser.blockIterator.BaseBlocksInRange(baseBlockHash, blockHash)
+			numMissingBaseBlocks := replica.rebaser.blockIterator.MissedBaseBlocksInRange(baseBlockHash, blockHash)
 			if numMissingBaseBlocks == 0 {
 				// If we have missed a base block, we drop the Propose. The
 				// Propose that justifies the next base block will eventually be

--- a/replica/replica_suite_test.go
+++ b/replica/replica_suite_test.go
@@ -75,7 +75,7 @@ func (m mockBlockIterator) NextBlock(kind block.Kind, height block.Height, shard
 	return RandomBytesSlice(), RandomBytesSlice(), RandomBytesSlice()
 }
 
-func (m mockBlockIterator) BaseBlocksInRange(begin, end id.Hash) int {
+func (m mockBlockIterator) MissedBaseBlocksInRange(begin, end id.Hash) int {
 	return 0 // mockBlockIterator does not support rebasing.
 }
 

--- a/testutil/replica/replica.go
+++ b/testutil/replica/replica.go
@@ -78,7 +78,7 @@ func (m *MockBlockIterator) NextBlock(kind block.Kind, height block.Height, shar
 	}
 }
 
-func (m *MockBlockIterator) BaseBlocksInRange(begin, end id.Hash) int {
+func (m *MockBlockIterator) MissedBaseBlocksInRange(begin, end id.Hash) int {
 	return 0 // MockBlockIterator does not support rebasing.
 }
 


### PR DESCRIPTION
This PR renames `BaseBlocksInRange` to `MissedBaseBlocksInRange` and improves documentation for the function as it was not clear that "between two blocks" was exclusive.