### PR TITLE
Ensure number of signatories does not change

### DIFF
--- a/replica/rebase.go
+++ b/replica/rebase.go
@@ -45,6 +45,7 @@ type shardRebaser struct {
 
 	expectedKind       block.Kind
 	expectedRebaseSigs id.Signatories
+	numSignatories     int
 
 	blockStorage  BlockStorage
 	blockIterator BlockIterator
@@ -53,12 +54,13 @@ type shardRebaser struct {
 	shard         Shard
 }
 
-func newShardRebaser(blockStorage BlockStorage, blockIterator BlockIterator, validator Validator, observer Observer, shard Shard) *shardRebaser {
+func newShardRebaser(blockStorage BlockStorage, blockIterator BlockIterator, validator Validator, observer Observer, shard Shard, numSignatories int) *shardRebaser {
 	return &shardRebaser{
 		mu: new(sync.Mutex),
 
 		expectedKind:       block.Standard,
 		expectedRebaseSigs: nil,
+		numSignatories:     numSignatories,
 
 		blockStorage:  blockStorage,
 		blockIterator: blockIterator,
@@ -138,6 +140,9 @@ func (rebaser *shardRebaser) IsBlockValid(proposedBlock block.Block, checkHistor
 		}
 
 	case block.Rebase:
+		if !len(proposedBlock.Header().Signatories()) != rebaser.numSignatories {
+			return nilReasons, fmt.Errorf("unexpected number of signatories in rebase block: expected %d, got %d", (rebaser.numSignatories, len(proposedBlock.Header().Signatories())) 
+		}
 		if !proposedBlock.Header().Signatories().Equal(rebaser.expectedRebaseSigs) {
 			return nilReasons, fmt.Errorf("unexpected signatories in rebase block: expected %d, got %d", len(rebaser.expectedRebaseSigs), len(proposedBlock.Header().Signatories()))
 		}

--- a/replica/rebase.go
+++ b/replica/rebase.go
@@ -140,8 +140,8 @@ func (rebaser *shardRebaser) IsBlockValid(proposedBlock block.Block, checkHistor
 		}
 
 	case block.Rebase:
-		if !len(proposedBlock.Header().Signatories()) != rebaser.numSignatories {
-			return nilReasons, fmt.Errorf("unexpected number of signatories in rebase block: expected %d, got %d", (rebaser.numSignatories, len(proposedBlock.Header().Signatories())) 
+		if len(proposedBlock.Header().Signatories()) != rebaser.numSignatories {
+			return nilReasons, fmt.Errorf("unexpected number of signatories in rebase block: expected %d, got %d", rebaser.numSignatories, len(proposedBlock.Header().Signatories()))
 		}
 		if !proposedBlock.Header().Signatories().Equal(rebaser.expectedRebaseSigs) {
 			return nilReasons, fmt.Errorf("unexpected signatories in rebase block: expected %d, got %d", len(rebaser.expectedRebaseSigs), len(proposedBlock.Header().Signatories()))

--- a/replica/rebase_test.go
+++ b/replica/rebase_test.go
@@ -26,10 +26,10 @@ var _ = Describe("shardRebaser", func() {
 
 	Context("initializing a new shardRebaser", func() {
 		It("should implements the process.Proposer", func() {
-			test := func(shard Shard) bool {
+			test := func(shard Shard, numSignatories int) bool {
 				store, initHeight, _ := initStorage(shard)
 				iter := mockBlockIterator{}
-				rebaser := newShardRebaser(store, iter, nil, nil, shard)
+				rebaser := newShardRebaser(store, iter, nil, nil, shard, numSignatories)
 
 				parent := store.LatestBlock(shard)
 				base := store.LatestBaseBlock(shard)
@@ -49,11 +49,11 @@ var _ = Describe("shardRebaser", func() {
 		})
 
 		It("should implements the process.Validator", func() {
-			test := func(shard Shard) bool {
+			test := func(shard Shard, numSignatories int) bool {
 				store, initHeight, _ := initStorage(shard)
 				iter := mockBlockIterator{}
 				validator := newMockValidator(nil)
-				rebaser := newShardRebaser(store, iter, validator, nil, shard)
+				rebaser := newShardRebaser(store, iter, validator, nil, shard, numSignatories)
 
 				// Generate a valid propose block.
 				parent := store.LatestBlock(shard)
@@ -73,11 +73,11 @@ var _ = Describe("shardRebaser", func() {
 		})
 
 		It("should implement the process.Observer", func() {
-			test := func(shard Shard) bool {
+			test := func(shard Shard, numSignatories int) bool {
 				store, initHeight, _ := initStorage(shard)
 				iter := mockBlockIterator{}
 				observer := newMockObserver()
-				rebaser := newShardRebaser(store, iter, nil, observer, shard)
+				rebaser := newShardRebaser(store, iter, nil, observer, shard, numSignatories)
 
 				rebaser.DidCommitBlock(0)
 				rebaser.DidCommitBlock(initHeight)
@@ -99,7 +99,7 @@ var _ = Describe("shardRebaser", func() {
 			test := func(shard Shard, sigs id.Signatories) bool {
 				store, _, _ := initStorage(shard)
 				iter := mockBlockIterator{}
-				rebaser := newShardRebaser(store, iter, nil, nil, shard)
+				rebaser := newShardRebaser(store, iter, nil, nil, shard, len(sigs))
 
 				rebaser.rebase(sigs)
 				Expect(rebaser.expectedKind).Should(Equal(block.Rebase))
@@ -122,7 +122,7 @@ var _ = Describe("shardRebaser", func() {
 				}
 				store, initHeight, _ := initStorage(shard)
 				iter := mockBlockIterator{}
-				rebaser := newShardRebaser(store, iter, nil, nil, shard)
+				rebaser := newShardRebaser(store, iter, nil, nil, shard, len(sigs))
 
 				rebaser.rebase(sigs)
 				parent := store.LatestBlock(shard)
@@ -160,7 +160,7 @@ var _ = Describe("shardRebaser", func() {
 				}
 				store, initHeight, _ := initStorage(shard)
 				iter := mockBlockIterator{}
-				rebaser := newShardRebaser(store, iter, nil, nil, shard)
+				rebaser := newShardRebaser(store, iter, nil, nil, shard, len(sigs))
 				rebaser.rebase(sigs)
 
 				// Generate a valid rebase block.

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -103,10 +103,11 @@ type Replicas []Replica
 // to a specific Shard. It signs Messages before sending them to other Replicas,
 // and verifies Messages before accepting them from other Replicas.
 type Replica struct {
-	options      Options
-	shard        Shard
-	p            *process.Process
-	blockStorage BlockStorage
+	options        Options
+	shard          Shard
+	p              *process.Process
+	numSignatories int
+	blockStorage   BlockStorage
 
 	scheduler schedule.Scheduler
 	rebaser   *shardRebaser
@@ -118,17 +119,18 @@ type Replica struct {
 func New(options Options, pStorage ProcessStorage, blockStorage BlockStorage, blockIterator BlockIterator, validator Validator, observer Observer, broadcaster Broadcaster, scheduler schedule.Scheduler, catcher process.Catcher, shard Shard, privKey ecdsa.PrivateKey) Replica {
 	options.setZerosToDefaults()
 	latestBase := blockStorage.LatestBaseBlock(shard)
-	if len(latestBase.Header().Signatories())%3 != 1 || len(latestBase.Header().Signatories()) < 4 {
-		panic(fmt.Errorf("invariant violation: number of nodes needs to be 3f +1, got %v", len(latestBase.Header().Signatories())))
+	numSignatories := len(latestBase.Header().Signatories())
+	if numSignatories%3 != 1 || numSignatories < 4 {
+		panic(fmt.Errorf("invariant violation: number of nodes needs to be 3f +1, got %v", numSignatories))
 	}
-	shardRebaser := newShardRebaser(blockStorage, blockIterator, validator, observer, shard)
+	shardRebaser := newShardRebaser(blockStorage, blockIterator, validator, observer, shard, numSignatories)
 
 	// Create a Process in the default state and then restore it
 	p := process.New(
 		options.Logger,
 		id.NewSignatory(privKey.PublicKey),
 		blockStorage.Blockchain(shard),
-		process.DefaultState((len(latestBase.Header().Signatories())-1)/3),
+		process.DefaultState((numSignatories-1)/3),
 		newSaveRestorer(pStorage, shard),
 		shardRebaser,
 		shardRebaser,
@@ -141,10 +143,11 @@ func New(options Options, pStorage ProcessStorage, blockStorage BlockStorage, bl
 	p.Restore()
 
 	return Replica{
-		options:      options,
-		shard:        shard,
-		p:            p,
-		blockStorage: blockStorage,
+		options:        options,
+		shard:          shard,
+		p:              p,
+		numSignatories: numSignatories,
+		blockStorage:   blockStorage,
 
 		scheduler: scheduler,
 		rebaser:   shardRebaser,
@@ -262,6 +265,9 @@ func (replica *Replica) HandleMessage(m Message) {
 }
 
 func (replica *Replica) Rebase(sigs id.Signatories) {
+	if len(sigs) != replica.numSignatories {
+		panic(fmt.Errorf("invariant violation: number of signatories must not change: expected %v, got %v", replica.numSignatories, len(sigs)))
+	}
 	if len(sigs)%3 != 1 || len(sigs) < 4 {
 		panic(fmt.Errorf("invariant violation: number of nodes needs to be 3f +1, got %v", len(sigs)))
 	}


### PR DESCRIPTION
Previously, changing the length of the signatories caused the `firstTime...` functions of the Inbox to be calculated incorrectly as the `f` value was not updated. This PR restricts rebasing to include the same number of signatories as it previously had (this can be an area for future improvement).