### PR TITLE
support for arbitrary state: height

### DIFF
--- a/process/state.go
+++ b/process/state.go
@@ -64,6 +64,27 @@ func DefaultState() State {
 	}
 }
 
+// WithCurrentHeight returns a process state having modified its current height
+// with the given height
+func (state State) WithCurrentHeight(height Height) State {
+	state.CurrentHeight = height
+	return state
+}
+
+// WithCurrentRound returns a process state having modified its current round
+// with the given round
+func (state State) WithCurrentRound(round Round) State {
+	state.CurrentRound = round
+	return state
+}
+
+// WithCurrentStep returns a process state having modified its current step
+// with the given step
+func (state State) WithCurrentStep(step Step) State {
+	state.CurrentStep = step
+	return state
+}
+
 // Clone the State into another copy that can be modified without affecting the
 // original.
 func (state State) Clone() State {

--- a/process/state.go
+++ b/process/state.go
@@ -71,20 +71,6 @@ func (state State) WithCurrentHeight(height Height) State {
 	return state
 }
 
-// WithCurrentRound returns a process state having modified its current round
-// with the given round
-func (state State) WithCurrentRound(round Round) State {
-	state.CurrentRound = round
-	return state
-}
-
-// WithCurrentStep returns a process state having modified its current step
-// with the given step
-func (state State) WithCurrentStep(step Step) State {
-	state.CurrentStep = step
-	return state
-}
-
 // Clone the State into another copy that can be modified without affecting the
 // original.
 func (state State) Clone() State {

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -214,13 +214,11 @@ func (replica *Replica) TimeoutPrecommit(ctx context.Context, timeout timer.Time
 	}
 }
 
-// UpdateState updates the state of the replica's underlying process with the
+// UpdateHeight updates the state of the replica's underlying process with the
 // given height, round and step
-func (replica *Replica) UpdateState(height process.Height, round process.Round, step process.Step) {
+func (replica *Replica) UpdateHeight(height process.Height) {
 	replica.proc.State = process.DefaultState().
-		WithCurrentHeight(height).
-		WithCurrentRound(round).
-		WithCurrentStep(step)
+		WithCurrentHeight(height)
 }
 
 // State returns the current height, round and step of the replica's underlying

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -223,6 +223,12 @@ func (replica *Replica) UpdateState(height process.Height, round process.Round, 
 		WithCurrentStep(step)
 }
 
+// State returns the current height, round and step of the replica's underlying
+// process
+func (replica Replica) State() (process.Height, process.Round, process.Step) {
+	return replica.proc.CurrentHeight, replica.proc.CurrentRound, replica.proc.CurrentStep
+}
+
 // CurrentHeight returns the height (in terms of block number) that the replica
 // is currently at
 func (replica Replica) CurrentHeight() process.Height {

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -214,6 +214,15 @@ func (replica *Replica) TimeoutPrecommit(ctx context.Context, timeout timer.Time
 	}
 }
 
+// UpdateState updates the state of the replica's underlying process with the
+// given height, round and step
+func (replica *Replica) UpdateState(height process.Height, round process.Round, step process.Step) {
+	replica.proc.State = process.DefaultState().
+		WithCurrentHeight(height).
+		WithCurrentRound(round).
+		WithCurrentStep(step)
+}
+
 // CurrentHeight returns the height (in terms of block number) that the replica
 // is currently at
 func (replica Replica) CurrentHeight() process.Height {

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -214,11 +214,12 @@ func (replica *Replica) TimeoutPrecommit(ctx context.Context, timeout timer.Time
 	}
 }
 
-// UpdateHeight updates the state of the replica's underlying process with the
-// given height, round and step
-func (replica *Replica) UpdateHeight(height process.Height) {
+// ResetHeight updates the state of the replica's underlying process with the
+// given new height. This is only meant to be used while resynchronising the
+// chain with the most up-to-date chain, hence modifying the height.
+func (replica *Replica) ResetHeight(newHeight process.Height) {
 	replica.proc.State = process.DefaultState().
-		WithCurrentHeight(height)
+		WithCurrentHeight(newHeight)
 }
 
 // State returns the current height, round and step of the replica's underlying


### PR DESCRIPTION
After resyncing the state of a node, we wish to update the height of the replica in the consensus mechanism.