### PR TITLE
constrain to f+1 unique signatories to skip to future round

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -756,10 +756,12 @@ func (p *Process) insertPropose(propose Propose) bool {
 
 	p.ProposeLogs[propose.Round] = propose
 
+	// add the proposer to the appropriate round's trace logs
 	if _, ok := p.TraceLogs[propose.Round]; !ok {
 		p.TraceLogs[propose.Round] = map[id.Signatory]bool{}
 	}
 	p.TraceLogs[propose.Round][propose.From] = true
+
 	return true
 }
 
@@ -771,9 +773,6 @@ func (p *Process) insertPrevote(prevote Prevote) bool {
 	}
 	if _, ok := p.PrevoteLogs[prevote.Round]; !ok {
 		p.PrevoteLogs[prevote.Round] = map[id.Signatory]Prevote{}
-	}
-	if _, ok := p.TraceLogs[prevote.Round]; !ok {
-		p.TraceLogs[prevote.Round] = map[id.Signatory]bool{}
 	}
 
 	existingPrevote, ok := p.PrevoteLogs[prevote.Round][prevote.From]
@@ -792,7 +791,13 @@ func (p *Process) insertPrevote(prevote Prevote) bool {
 	}
 
 	p.PrevoteLogs[prevote.Round][prevote.From] = prevote
+
+	// add the prevoter to the appropriate round's trace logs
+	if _, ok := p.TraceLogs[prevote.Round]; !ok {
+		p.TraceLogs[prevote.Round] = map[id.Signatory]bool{}
+	}
 	p.TraceLogs[prevote.Round][prevote.From] = true
+
 	return true
 }
 
@@ -805,9 +810,6 @@ func (p *Process) insertPrecommit(precommit Precommit) bool {
 	}
 	if _, ok := p.PrecommitLogs[precommit.Round]; !ok {
 		p.PrecommitLogs[precommit.Round] = map[id.Signatory]Precommit{}
-	}
-	if _, ok := p.TraceLogs[precommit.Round]; !ok {
-		p.TraceLogs[precommit.Round] = map[id.Signatory]bool{}
 	}
 
 	existingPrecommit, ok := p.PrecommitLogs[precommit.Round][precommit.From]
@@ -826,7 +828,13 @@ func (p *Process) insertPrecommit(precommit Precommit) bool {
 	}
 
 	p.PrecommitLogs[precommit.Round][precommit.From] = precommit
+
+	// add the precommitter to the appropriate round's trace logs
+	if _, ok := p.TraceLogs[precommit.Round]; !ok {
+		p.TraceLogs[precommit.Round] = map[id.Signatory]bool{}
+	}
 	p.TraceLogs[precommit.Round][precommit.From] = true
+
 	return true
 }
 

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -2834,107 +2834,208 @@ var _ = Describe("Process", func() {
 		}
 
 		Context("when there are f+1 unique signatories", func() {
-			It("should start a new round set as the given future round", func() {
-				loop := func() bool {
-					currentHeight := process.Height(r.Int63())
-					currentRound := process.Round(r.Int63())
-					whoami := id.NewPrivKey().Signatory()
-					f := 5 + (r.Int() % 10)
+			Context("with f+1 prevotes", func() {
+				It("should skip to future round", func() {
+					loop := func() bool {
+						currentHeight := process.Height(r.Int63())
+						currentRound := process.Round(r.Int63())
+						futureRound := currentRound + 1 + process.Round(r.Int()%10)
+						whoami := id.NewPrivKey().Signatory()
+						f := 5 + (r.Int() % 10)
 
-					// instantiate a new process
-					p := process.New(whoami, f, nil, nil, nil, nil, nil, nil, nil)
-					p.StartRound(currentRound)
-					p.State.CurrentHeight = currentHeight
+						// instantiate a new process
+						p := process.New(whoami, f, nil, nil, nil, nil, nil, nil, nil)
+						p.StartRound(currentRound)
+						p.State.CurrentHeight = currentHeight
 
-					// f+1 unique signatories
-					signatories := make([]id.Signatory, f+1)
-					for i := range signatories {
-						signatories[i] = id.NewPrivKey().Signatory()
-					}
-
-					// feed with 1 propose message
-					futureRound := currentRound + 1 + process.Round(r.Int()%10)
-					propose := processutil.RandomPropose(r)
-					propose.From = signatories[0]
-					propose.Height = currentHeight
-					propose.Round = futureRound
-					p.Propose(propose)
-
-					// feed with f prevote/precommit messages
-					for t := 0; t < f; t++ {
-						switch r.Int() % 2 {
-						case 0:
-							msg := randomValidPrevote(r, currentHeight, futureRound)
-							msg.From = signatories[t+1]
-							p.Prevote(msg)
-						case 1:
-							msg := randomValidPrecommit(r, currentHeight, futureRound)
-							msg.From = signatories[t+1]
-							p.Precommit(msg)
-						default:
-							panic("this should never happen")
+						// f+1 unique signatories
+						signatories := make([]id.Signatory, f+1)
+						for i := range signatories {
+							signatories[i] = id.NewPrivKey().Signatory()
 						}
+
+						// feed f+1 precommit messages
+						for t := 0; t < f+1; t++ {
+							msg := randomValidPrevote(r, currentHeight, futureRound)
+							msg.From = signatories[t]
+							p.Prevote(msg)
+						}
+
+						// the process should have moved to the future round
+						Expect(p.State.CurrentRound).To(Equal(futureRound))
+
+						return true
 					}
+					Expect(quick.Check(loop, nil)).To(Succeed())
+				})
+			})
 
-					// the process should have moved to the future round
-					Expect(p.State.CurrentRound).To(Equal(futureRound))
+			Context("with f+1 precommits", func() {
+				It("should skip to future round", func() {
+					loop := func() bool {
+						currentHeight := process.Height(r.Int63())
+						currentRound := process.Round(r.Int63())
+						futureRound := currentRound + 1 + process.Round(r.Int()%10)
+						whoami := id.NewPrivKey().Signatory()
+						f := 5 + (r.Int() % 10)
 
-					return true
-				}
-				Expect(quick.Check(loop, nil)).To(Succeed())
+						// instantiate a new process
+						p := process.New(whoami, f, nil, nil, nil, nil, nil, nil, nil)
+						p.StartRound(currentRound)
+						p.State.CurrentHeight = currentHeight
+
+						// f+1 unique signatories
+						signatories := make([]id.Signatory, f+1)
+						for i := range signatories {
+							signatories[i] = id.NewPrivKey().Signatory()
+						}
+
+						// feed f+1 precommit messages
+						for t := 0; t < f+1; t++ {
+							msg := randomValidPrecommit(r, currentHeight, futureRound)
+							msg.From = signatories[t]
+							p.Precommit(msg)
+						}
+
+						// the process should have moved to the future round
+						Expect(p.State.CurrentRound).To(Equal(futureRound))
+
+						return true
+					}
+					Expect(quick.Check(loop, nil)).To(Succeed())
+				})
+			})
+
+			Context("with f+1 messages (propose/prevote/precommit)", func() {
+				It("should start a new round set as the given future round", func() {
+					loop := func() bool {
+						currentHeight := process.Height(r.Int63())
+						currentRound := process.Round(r.Int63())
+						futureRound := currentRound + 1 + process.Round(r.Int()%10)
+						whoami := id.NewPrivKey().Signatory()
+						f := 5 + (r.Int() % 10)
+
+						// instantiate a new process
+						p := process.New(whoami, f, nil, nil, nil, nil, nil, nil, nil)
+						p.StartRound(currentRound)
+						p.State.CurrentHeight = currentHeight
+
+						// f+1 unique signatories
+						signatories := make([]id.Signatory, f+1)
+						for i := range signatories {
+							signatories[i] = id.NewPrivKey().Signatory()
+						}
+
+						// store f+1 messages (1 propose, f prevotes/precommits)
+						messages := make([]interface{}, 0, f+1)
+						propose := processutil.RandomPropose(r)
+						propose.From = signatories[0]
+						propose.Height = currentHeight
+						propose.Round = futureRound
+						messages = append(messages, propose)
+
+						// append f prevote/precommit messages
+						for t := 0; t < f; t++ {
+							switch r.Int() % 2 {
+							case 0:
+								msg := randomValidPrevote(r, currentHeight, futureRound)
+								msg.From = signatories[t+1]
+								messages = append(messages, msg)
+							case 1:
+								msg := randomValidPrecommit(r, currentHeight, futureRound)
+								msg.From = signatories[t+1]
+								messages = append(messages, msg)
+							default:
+								panic("this should never happen")
+							}
+						}
+
+						// shuffle messages
+						r.Shuffle(len(messages), func(i, j int) {
+							messages[i], messages[j] = messages[j], messages[i]
+						})
+
+						// feed those messages
+						for _, msg := range messages {
+							switch msg := msg.(type) {
+							case process.Propose:
+								p.Propose(msg)
+							case process.Prevote:
+								p.Prevote(msg)
+							case process.Precommit:
+								p.Precommit(msg)
+							}
+						}
+
+						// the process should have moved to the future round
+						Expect(p.State.CurrentRound).To(Equal(futureRound))
+
+						return true
+					}
+					Expect(quick.Check(loop, nil)).To(Succeed())
+				})
 			})
 		})
 
-		FContext("when there are less than f+1 unique signatories", func() {
-			It("should do nothing", func() {
-				loop := func() bool {
-					currentHeight := process.Height(r.Int63())
-					currentRound := process.Round(r.Int63())
-					whoami := id.NewPrivKey().Signatory()
-					f := 5 + (r.Int() % 10)
+		Context("when there are less than f+1 unique signatories", func() {
+			Context("with f unique signatories for 2f messages (f prevotes + f precommits)", func() {
+				It("should do nothing", func() {
+					loop := func() bool {
+						currentHeight := process.Height(r.Int63())
+						currentRound := process.Round(r.Int63())
+						futureRound := currentRound + 1 + process.Round(r.Int()%10)
+						whoami := id.NewPrivKey().Signatory()
+						f := 5 + (r.Int() % 10)
 
-					// instantiate a new process
-					p := process.New(whoami, f, nil, nil, nil, nil, nil, nil, nil)
-					p.StartRound(currentRound)
-					p.State.CurrentHeight = currentHeight
+						// instantiate a new process
+						p := process.New(whoami, f, nil, nil, nil, nil, nil, nil, nil)
+						p.StartRound(currentRound)
+						p.State.CurrentHeight = currentHeight
 
-					// f+1 signatories with the 2 being the same
-					signatories := make([]id.Signatory, f+1)
-					for i := range signatories {
-						signatories[i] = id.NewPrivKey().Signatory()
-					}
-					signatories[f] = signatories[r.Intn(f)]
-
-					// feed with 1 propose message
-					futureRound := currentRound + 1 + process.Round(r.Int()%10)
-					propose := processutil.RandomPropose(r)
-					propose.From = signatories[0]
-					propose.Height = currentHeight
-					propose.Round = futureRound
-					p.Propose(propose)
-
-					// feed with f prevote/precommit messages
-					for t := 0; t < f; t++ {
-						switch r.Int() % 2 {
-						case 0:
-							msg := randomValidPrevote(r, currentHeight, futureRound)
-							msg.From = signatories[t+1]
-							p.Prevote(msg)
-						case 1:
-							msg := randomValidPrecommit(r, currentHeight, futureRound)
-							msg.From = signatories[t+1]
-							p.Precommit(msg)
-						default:
-							panic("this should never happen")
+						// f unique signatories
+						signatories := make([]id.Signatory, f)
+						for i := range signatories {
+							signatories[i] = id.NewPrivKey().Signatory()
 						}
+
+						// 2f messages (f prevotes, f precommits)
+						messages := make([]interface{}, 0, 2*f)
+
+						// feed with f prevote/precommit messages
+						for t := 0; t < f; t++ {
+							prevote := randomValidPrevote(r, currentHeight, futureRound)
+							prevote.From = signatories[t]
+							messages = append(messages, prevote)
+
+							precommit := randomValidPrecommit(r, currentHeight, futureRound)
+							precommit.From = signatories[t]
+							messages = append(messages, precommit)
+						}
+
+						// shuffle messages
+						r.Shuffle(len(messages), func(i, j int) {
+							messages[i], messages[j] = messages[j], messages[i]
+						})
+
+						// feed those messages
+						for _, msg := range messages {
+							switch msg := msg.(type) {
+							case process.Propose:
+								p.Propose(msg)
+							case process.Prevote:
+								p.Prevote(msg)
+							case process.Precommit:
+								p.Precommit(msg)
+							}
+						}
+
+						// the process should have moved to the future round
+						Expect(p.State.CurrentRound).To(Equal(currentRound))
+
+						return true
 					}
-
-					// the process should have moved to the future round
-					Expect(p.State.CurrentRound).To(Equal(currentRound))
-
-					return true
-				}
-				Expect(quick.Check(loop, nil)).To(Succeed())
+					Expect(quick.Check(loop, nil)).To(Succeed())
+				})
 			})
 		})
 

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -1406,7 +1406,7 @@ var _ = Describe("Process", func() {
 					prevoteMsg := randomValidPrevoteMsg(r, id.NewPrivKey().Signatory(), process.Height(1), currentRound)
 					p.Prevote(prevoteMsg)
 
-					time.Sleep(5 * time.Millisecond)
+					time.Sleep(10 * time.Millisecond)
 					select {
 					case timeout := <-timeoutSignal:
 						Expect(timeout.Round).To(Equal(currentRound))
@@ -1546,7 +1546,7 @@ var _ = Describe("Process", func() {
 								From:       id.NewPrivKey().Signatory(),
 							})
 
-							time.Sleep(5 * time.Millisecond)
+							time.Sleep(10 * time.Millisecond)
 
 							select {
 							case timeout := <-timeoutSignal:

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -3037,6 +3037,69 @@ var _ = Describe("Process", func() {
 					Expect(quick.Check(loop, nil)).To(Succeed())
 				})
 			})
+
+			Context("with f unique signatories for f+1 messages (1 propose, f prevotes)", func() {
+				It("should do nothing", func() {
+					loop := func() bool {
+						currentHeight := process.Height(r.Int63())
+						currentRound := process.Round(r.Int63())
+						futureRound := currentRound + 1 + process.Round(r.Int()%10)
+						whoami := id.NewPrivKey().Signatory()
+						f := 5 + (r.Int() % 10)
+
+						// instantiate a new process
+						p := process.New(whoami, f, nil, nil, nil, nil, nil, nil, nil)
+						p.StartRound(currentRound)
+						p.State.CurrentHeight = currentHeight
+
+						// f unique signatories
+						signatories := make([]id.Signatory, f)
+						for i := range signatories {
+							signatories[i] = id.NewPrivKey().Signatory()
+						}
+
+						// 2f messages (f prevotes, f precommits)
+						messages := make([]interface{}, 0, 2*f)
+
+						// feed with f prevote messages
+						for t := 0; t < f; t++ {
+							prevote := randomValidPrevote(r, currentHeight, futureRound)
+							prevote.From = signatories[t]
+							messages = append(messages, prevote)
+						}
+
+						// add a propose message
+						propose := processutil.RandomPropose(r)
+						propose.From = signatories[r.Intn(f)]
+						propose.Height = currentHeight
+						propose.Round = futureRound
+						messages = append(messages, propose)
+
+						// shuffle messages
+						r.Shuffle(len(messages), func(i, j int) {
+							messages[i], messages[j] = messages[j], messages[i]
+						})
+
+						// feed those messages
+						for _, msg := range messages {
+							switch msg := msg.(type) {
+							case process.Propose:
+								p.Propose(msg)
+							case process.Prevote:
+								p.Prevote(msg)
+							case process.Precommit:
+								p.Precommit(msg)
+							}
+						}
+
+						// the process should have moved to the future round
+						Expect(p.State.CurrentRound).To(Equal(currentRound))
+
+						return true
+					}
+					Expect(quick.Check(loop, nil)).To(Succeed())
+				})
+			})
 		})
 
 		It("should start a new round set as the given future round", func() {

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -2854,7 +2854,7 @@ var _ = Describe("Process", func() {
 							signatories[i] = id.NewPrivKey().Signatory()
 						}
 
-						// feed f+1 precommit messages
+						// feed f+1 prevote messages
 						for t := 0; t < f+1; t++ {
 							msg := randomValidPrevote(r, currentHeight, futureRound)
 							msg.From = signatories[t]
@@ -2945,8 +2945,6 @@ var _ = Describe("Process", func() {
 								msg := randomValidPrecommit(r, currentHeight, futureRound)
 								msg.From = signatories[t+1]
 								messages = append(messages, msg)
-							default:
-								panic("this should never happen")
 							}
 						}
 
@@ -3029,7 +3027,7 @@ var _ = Describe("Process", func() {
 							}
 						}
 
-						// the process should have moved to the future round
+						// the process should remain in the current round
 						Expect(p.State.CurrentRound).To(Equal(currentRound))
 
 						return true
@@ -3058,8 +3056,8 @@ var _ = Describe("Process", func() {
 							signatories[i] = id.NewPrivKey().Signatory()
 						}
 
-						// 2f messages (f prevotes, f precommits)
-						messages := make([]interface{}, 0, 2*f)
+						// f+1 messages (1 propose, f prevotes)
+						messages := make([]interface{}, 0, f+1)
 
 						// feed with f prevote messages
 						for t := 0; t < f; t++ {
@@ -3092,7 +3090,7 @@ var _ = Describe("Process", func() {
 							}
 						}
 
-						// the process should have moved to the future round
+						// the process should remain in the current round
 						Expect(p.State.CurrentRound).To(Equal(currentRound))
 
 						return true

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -2906,7 +2906,7 @@ var _ = Describe("Process", func() {
 				})
 			})
 
-			Context("with f+1 messages (propose/prevote/precommit)", func() {
+			Context("with f+1 messages proposes/prevotes/precommits", func() {
 				It("should start a new round set as the given future round", func() {
 					loop := func() bool {
 						currentHeight := process.Height(r.Int63())

--- a/process/state.go
+++ b/process/state.go
@@ -42,8 +42,8 @@ type State struct {
 	PrecommitLogs map[Round]map[id.Signatory]Precommit `json:"precommitLogs"`
 	// OnceFlags prevents events from happening more than once.
 	OnceFlags map[Round]OnceFlag `json:"onceFlags"`
-	// TraceLogs store the unique signatories from which we have received prevote
-	// or precommit messages in a specific round for the current height
+	// TraceLogs store the unique signatories from which we have received a msg
+	// (propose/prevote/precommit) in a specific round for the current height
 	TraceLogs map[Round]map[id.Signatory]bool
 }
 

--- a/process/state.go
+++ b/process/state.go
@@ -42,6 +42,9 @@ type State struct {
 	PrecommitLogs map[Round]map[id.Signatory]Precommit `json:"precommitLogs"`
 	// OnceFlags prevents events from happening more than once.
 	OnceFlags map[Round]OnceFlag `json:"onceFlags"`
+	// TraceLogs store the unique signatories from which we have received prevote
+	// or precommit messages in a specific round for the current height
+	TraceLogs map[Round]map[id.Signatory]bool
 }
 
 // DefaultState returns a State with all fields set to their default values. The
@@ -61,6 +64,7 @@ func DefaultState() State {
 		PrevoteLogs:   make(map[Round]map[id.Signatory]Prevote),
 		PrecommitLogs: make(map[Round]map[id.Signatory]Precommit),
 		OnceFlags:     make(map[Round]OnceFlag),
+		TraceLogs:     make(map[Round]map[id.Signatory]bool),
 	}
 }
 
@@ -80,6 +84,7 @@ func (state State) Clone() State {
 		PrevoteLogs:   make(map[Round]map[id.Signatory]Prevote),
 		PrecommitLogs: make(map[Round]map[id.Signatory]Precommit),
 		OnceFlags:     make(map[Round]OnceFlag),
+		TraceLogs:     make(map[Round]map[id.Signatory]bool),
 	}
 	for round, propose := range state.ProposeLogs {
 		cloned.ProposeLogs[round] = propose
@@ -98,6 +103,12 @@ func (state State) Clone() State {
 	}
 	for round, onceFlag := range state.OnceFlags {
 		cloned.OnceFlags[round] = onceFlag
+	}
+	for round, traces := range state.TraceLogs {
+		cloned.TraceLogs[round] = make(map[id.Signatory]bool)
+		for signatory, trace := range traces {
+			cloned.TraceLogs[round][signatory] = trace
+		}
 	}
 	return cloned
 }
@@ -128,7 +139,8 @@ func (state State) SizeHint() int {
 		surge.SizeHint(state.ProposeLogs) +
 		surge.SizeHint(state.PrevoteLogs) +
 		surge.SizeHint(state.PrecommitLogs) +
-		surge.SizeHint(state.OnceFlags)
+		surge.SizeHint(state.OnceFlags) +
+		surge.SizeHint(state.TraceLogs)
 }
 
 // Marshal implements the Surge Marshaler interface
@@ -176,6 +188,10 @@ func (state State) Marshal(buf []byte, rem int) ([]byte, int, error) {
 	buf, rem, err = surge.Marshal(state.OnceFlags, buf, rem)
 	if err != nil {
 		return buf, rem, fmt.Errorf("marshaling %v once flags: %v", len(state.OnceFlags), err)
+	}
+	buf, rem, err = surge.Marshal(state.TraceLogs, buf, rem)
+	if err != nil {
+		return buf, rem, fmt.Errorf("marshaling %v trace logs: %v", len(state.TraceLogs), err)
 	}
 	return buf, rem, nil
 }
@@ -225,6 +241,10 @@ func (state *State) Unmarshal(buf []byte, rem int) ([]byte, int, error) {
 	buf, rem, err = surge.Unmarshal(&state.OnceFlags, buf, rem)
 	if err != nil {
 		return buf, rem, fmt.Errorf("unmarshaling once flags: %v", err)
+	}
+	buf, rem, err = surge.Unmarshal(&state.TraceLogs, buf, rem)
+	if err != nil {
+		return buf, rem, fmt.Errorf("unmarshaling trace logs: %v", err)
 	}
 	return buf, rem, nil
 }


### PR DESCRIPTION
If the current round is r and the adversaries submit `f` Prevotes for `r+1` and `f` Precommits for `r+1`, then all honest nodes receiving them, will start round `r+1`. This is because of the way the trySkipToFutureRound function is implemented:
```go
msgsInRound += len(p.PrevoteLogs[round])
msgsInRound += len(p.PrecommitLogs[round])

if msgsInRound == p.f + 1 {
    p.StartRound(round)
}
```

When counting the messages only the total amount of messages is considered, there is no differentiation if they are from unique signatories. Hence, f/2+1 adversarial nodes are sufficient to execute this attack. By constantly advancing the round they can prevent consensus. The specification is imprecise what exactly the correct behaviour is in this case.

# Solution
Require messages from `f+1` unique signatories