### PR TITLE
add check to ignore a propose for an invalid round

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -687,6 +687,10 @@ func (p *Process) insertPropose(propose Propose) bool {
 		return false
 	}
 
+	if propose.Round <= InvalidRound {
+		return false
+	}
+
 	if p.scheduler != nil {
 		proposer := p.scheduler.Schedule(propose.Height, propose.Round)
 		if !proposer.Equal(&propose.From) {

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -791,7 +791,9 @@ var _ = Describe("Process", func() {
 							propose.From = scheduledProposer
 							propose.Height = currentHeight
 							propose.Round = process.Round(-r.Int63())
-							p.Propose(propose)
+							Expect(func() {
+								p.Propose(propose)
+							}).ToNot(Panic())
 
 							return true
 						}


### PR DESCRIPTION
An adversary can crash other peers in the system by causing a panic in their implementations. That can be done as follows: The adversary sends a Propose message with the current height and the Round value set to `process.InvalidRound`. The Propose is checked by consulting the Scheduler:
```go
if round <= process.InvalidRound {
    panic("invalid round")
}
```

The scheduler will panic and hence the node will crash. This way an adversary can crash the entire network and prevent any consensus progress.