### PR TITLE
change equality to gte

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -474,7 +474,7 @@ func (p *Process) tryTimeoutPrevoteUponSufficientPrevotes() {
 	if p.CurrentStep != Prevoting {
 		return
 	}
-	if len(p.PrevoteLogs[p.CurrentRound]) == 2*p.f+1 {
+	if len(p.PrevoteLogs[p.CurrentRound]) >= 2*p.f+1 {
 		if p.timer != nil {
 			p.timer.TimeoutPrevote(p.CurrentHeight, p.CurrentRound)
 			p.setOnceFlag(p.CurrentRound, OnceFlagTimeoutPrevoteUponSufficientPrevotes)
@@ -564,7 +564,7 @@ func (p *Process) tryPrecommitNilUponSufficientPrevotes() {
 			prevotesForNil++
 		}
 	}
-	if prevotesForNil == 2*p.f+1 {
+	if prevotesForNil >= 2*p.f+1 {
 		if p.broadcaster != nil {
 			p.broadcaster.BroadcastPrecommit(Precommit{
 				Height: p.CurrentHeight,
@@ -631,7 +631,7 @@ func (p *Process) tryCommitUponSufficientPrecommits(round Round) {
 			precommitsForValue++
 		}
 	}
-	if precommitsForValue == 2*p.f+1 {
+	if precommitsForValue >= 2*p.f+1 {
 		p.committer.Commit(p.CurrentHeight, propose.Value)
 		p.CurrentHeight++
 

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -940,8 +940,7 @@ var _ = Describe("Process", func() {
 										acknowledge := false
 										broadcaster := processutil.BroadcasterCallbacks{
 											BroadcastProposeCallback: func(msg process.Propose) {
-												// this should never get called
-												Expect(true).ToNot(BeTrue())
+												Fail("unexpectedly received a propose broadcast")
 											},
 											BroadcastPrevoteCallback: func(msg process.Prevote) {
 												Expect(msg.Value).To(Equal(proposedValue))
@@ -949,8 +948,7 @@ var _ = Describe("Process", func() {
 												acknowledge = true
 											},
 											BroadcastPrecommitCallback: func(msg process.Precommit) {
-												// this should never get called
-												Expect(true).ToNot(BeTrue())
+												Fail("unexpectedly received a precommit broadcast")
 											},
 										}
 										// create process and start this round
@@ -1008,8 +1006,7 @@ var _ = Describe("Process", func() {
 										acknowledge := false
 										broadcaster := processutil.BroadcasterCallbacks{
 											BroadcastProposeCallback: func(msg process.Propose) {
-												// this should never get called
-												Expect(true).ToNot(BeTrue())
+												Fail("unexpectedly received a propose broadcast")
 											},
 											BroadcastPrevoteCallback: func(msg process.Prevote) {
 												Expect(msg.Value).To(Equal(proposedValue))
@@ -1017,8 +1014,7 @@ var _ = Describe("Process", func() {
 												acknowledge = true
 											},
 											BroadcastPrecommitCallback: func(msg process.Precommit) {
-												// this should never get called
-												Expect(true).ToNot(BeTrue())
+												Fail("unexpectedly received a precommit broadcast")
 											},
 										}
 										// create process and start this round
@@ -1082,8 +1078,7 @@ var _ = Describe("Process", func() {
 										acknowledge := false
 										broadcaster := processutil.BroadcasterCallbacks{
 											BroadcastProposeCallback: func(msg process.Propose) {
-												// this should never get called
-												Expect(true).ToNot(BeTrue())
+												Fail("unexpectedly received a propose broadcast")
 											},
 											BroadcastPrevoteCallback: func(msg process.Prevote) {
 												// nil prevote
@@ -1092,8 +1087,7 @@ var _ = Describe("Process", func() {
 												acknowledge = true
 											},
 											BroadcastPrecommitCallback: func(msg process.Precommit) {
-												// this should never get called
-												Expect(true).ToNot(BeTrue())
+												Fail("unexpectedly received a precommit broadcast")
 											},
 										}
 										// create process and start this round
@@ -1153,8 +1147,7 @@ var _ = Describe("Process", func() {
 									acknowledge := false
 									broadcaster := processutil.BroadcasterCallbacks{
 										BroadcastProposeCallback: func(msg process.Propose) {
-											// this should never get called
-											Expect(true).ToNot(BeTrue())
+											Fail("unexpectedly received a propose broadcast")
 										},
 										BroadcastPrevoteCallback: func(msg process.Prevote) {
 											// nil prevote
@@ -1163,8 +1156,7 @@ var _ = Describe("Process", func() {
 											acknowledge = true
 										},
 										BroadcastPrecommitCallback: func(msg process.Precommit) {
-											// this should never get called
-											Expect(true).ToNot(BeTrue())
+											Fail("unexpectedly received a precommit broadcast")
 										},
 									}
 									// create process and start this round
@@ -1224,16 +1216,13 @@ var _ = Describe("Process", func() {
 								// broadcaster callbacks, only a prevote is expected
 								broadcaster := processutil.BroadcasterCallbacks{
 									BroadcastProposeCallback: func(msg process.Propose) {
-										// this should never get called
-										Expect(true).ToNot(BeTrue())
+										Fail("unexpectedly received a propose broadcast")
 									},
 									BroadcastPrevoteCallback: func(msg process.Prevote) {
-										// this should never get called
-										Expect(true).ToNot(BeTrue())
+										Fail("unexpectedly received a prevote broadcast")
 									},
 									BroadcastPrecommitCallback: func(msg process.Precommit) {
-										// this should never get called
-										Expect(true).ToNot(BeTrue())
+										Fail("unexpectedly received a precommit broadcast")
 									},
 								}
 								// create process and start this round
@@ -1286,8 +1275,7 @@ var _ = Describe("Process", func() {
 					}
 					broadcaster := processutil.BroadcasterCallbacks{
 						BroadcastPrevoteCallback: func(msg process.Prevote) {
-							// this should never get called
-							Expect(true).ToNot(BeTrue())
+							Fail("unexpectedly received a prevote broadcast")
 						},
 					}
 					p := process.New(whoami, f, nil, mockScheduler, nil, mockValidator, broadcaster, nil, nil)
@@ -1374,8 +1362,7 @@ var _ = Describe("Process", func() {
 						time.Sleep(5 * time.Millisecond)
 						select {
 						case _ = <-timeoutSignal:
-							// this should never happen
-							Expect(true).ToNot(BeTrue())
+							Fail("unexpectedly received a prevote timeout")
 						default:
 							Expect(true).To(BeTrue())
 						}
@@ -1391,8 +1378,7 @@ var _ = Describe("Process", func() {
 						Expect(timeout.Round).To(Equal(currentRound))
 						Expect(timeout.Height).To(Equal(process.Height(1)))
 					default:
-						// we do expect to receive a scheduled timeout
-						Expect(true).ToNot(BeTrue())
+						Fail("expected to receive a prevote timeout")
 					}
 
 					// should not schedule a timeout again (that the once flags work)
@@ -1402,8 +1388,7 @@ var _ = Describe("Process", func() {
 					time.Sleep(5 * time.Millisecond)
 					select {
 					case _ = <-timeoutSignal:
-						// this should never happen
-						Expect(true).ToNot(BeTrue())
+						Fail("unexpectedly received a prevote timeout")
 					default:
 						Expect(true).To(BeTrue())
 					}
@@ -1455,8 +1440,7 @@ var _ = Describe("Process", func() {
 						time.Sleep(5 * time.Millisecond)
 						select {
 						case _ = <-timeoutSignal:
-							// this should never happen
-							Expect(true).ToNot(BeTrue())
+							Fail("unexpectedly received a prevote timeout")
 						default:
 							Expect(true).To(BeTrue())
 						}
@@ -1469,10 +1453,8 @@ var _ = Describe("Process", func() {
 					time.Sleep(5 * time.Millisecond)
 					select {
 					case _ = <-timeoutSignal:
-						// this should never happen
-						Expect(true).ToNot(BeTrue())
+						Fail("unexpectedly received a prevote timeout")
 					default:
-						// we dont expect to receive any timeout
 						Expect(true).To(BeTrue())
 					}
 
@@ -1516,7 +1498,7 @@ var _ = Describe("Process", func() {
 							// make sure we haven't received any prevote timeout
 							select {
 							case _ = <-timeoutSignal:
-								Expect(true).To(BeFalse())
+								Fail("unexpectedly received a prevote timeout")
 							default:
 								Expect(true).To(BeTrue())
 							}
@@ -1537,7 +1519,7 @@ var _ = Describe("Process", func() {
 								Expect(timeout.Height).To(Equal(currentHeight))
 								Expect(timeout.Round).To(Equal(currentRound))
 							default:
-								Expect(true).To(BeFalse())
+								Fail("expected to receive a prevote timeout")
 							}
 
 							return true
@@ -1589,7 +1571,7 @@ var _ = Describe("Process", func() {
 							// make sure we still haven't received any timeout
 							select {
 							case _ = <-timeoutSignal:
-								Expect(true).To(BeFalse())
+								Fail("unexpectedly received a prevote timeout")
 							default:
 								Expect(true).To(BeTrue())
 							}
@@ -1650,12 +1632,10 @@ var _ = Describe("Process", func() {
 							acknowledge := false
 							broadcaster := processutil.BroadcasterCallbacks{
 								BroadcastProposeCallback: func(msg process.Propose) {
-									// we dont expect any propose
-									Expect(true).ToNot(BeTrue())
+									Fail("unexpectedly received a propose broadcast")
 								},
 								BroadcastPrevoteCallback: func(msg process.Prevote) {
-									// we dont expect any prevotes
-									Expect(true).ToNot(BeTrue())
+									Fail("unexpectedly received a prevote broadcast")
 								},
 								BroadcastPrecommitCallback: func(msg process.Precommit) {
 									Expect(msg.From.Equal(&whoami)).To(BeTrue())
@@ -1753,16 +1733,13 @@ var _ = Describe("Process", func() {
 
 							broadcaster := processutil.BroadcasterCallbacks{
 								BroadcastProposeCallback: func(msg process.Propose) {
-									// we dont expect any propose
-									Expect(true).ToNot(BeTrue())
+									Fail("unexpectedly received a propose broadcast")
 								},
 								BroadcastPrevoteCallback: func(msg process.Prevote) {
-									// we dont expect any prevotes
-									Expect(true).ToNot(BeTrue())
+									Fail("unexpectedly received a prevote broadcast")
 								},
 								BroadcastPrecommitCallback: func(msg process.Precommit) {
-									// we dont expect any prevotes
-									Expect(true).ToNot(BeTrue())
+									Fail("unexpectedly received a precommit broadcast")
 								},
 							}
 							scheduledProposer := id.NewPrivKey().Signatory()
@@ -1840,16 +1817,13 @@ var _ = Describe("Process", func() {
 
 						broadcaster := processutil.BroadcasterCallbacks{
 							BroadcastProposeCallback: func(msg process.Propose) {
-								// we dont expect any propose
-								Expect(true).ToNot(BeTrue())
+								Fail("unexpectedly received a propose broadcast")
 							},
 							BroadcastPrevoteCallback: func(msg process.Prevote) {
-								// we dont expect any prevotes
-								Expect(true).ToNot(BeTrue())
+								Fail("unexpectedly received a prevote broadcast")
 							},
 							BroadcastPrecommitCallback: func(msg process.Precommit) {
-								// we dont expect any prevotes
-								Expect(true).ToNot(BeTrue())
+								Fail("unexpectedly received a precommit broadcast")
 							},
 						}
 						scheduledProposer := id.NewPrivKey().Signatory()
@@ -1912,16 +1886,14 @@ var _ = Describe("Process", func() {
 
 					broadcaster := processutil.BroadcasterCallbacks{
 						BroadcastProposeCallback: func(msg process.Propose) {
-							// we dont expect any propose
-							Expect(true).ToNot(BeTrue())
+							Fail("unexpectedly received a propose broadcast")
 						},
 						BroadcastPrevoteCallback: func(msg process.Prevote) {
 							// the process will prevote nil (for the invalid propose)
 							Expect(msg.Value).To(Equal(process.NilValue))
 						},
 						BroadcastPrecommitCallback: func(msg process.Precommit) {
-							// we dont expect any prevotes
-							Expect(true).ToNot(BeTrue())
+							Fail("unexpectedly received a precommit broadcast")
 						},
 					}
 					scheduledProposer := id.NewPrivKey().Signatory()
@@ -1997,12 +1969,10 @@ var _ = Describe("Process", func() {
 					acknowledge := false
 					broadcaster := processutil.BroadcasterCallbacks{
 						BroadcastProposeCallback: func(msg process.Propose) {
-							// we expect to never receive propose broadcast
-							Expect(true).ToNot(BeTrue())
+							Fail("unexpectedly received a propose broadcast")
 						},
 						BroadcastPrevoteCallback: func(msg process.Prevote) {
-							// we expect to never receive prevote broadcast
-							Expect(true).ToNot(BeTrue())
+							Fail("unexpectedly received a prevote broadcast")
 						},
 						BroadcastPrecommitCallback: func(msg process.Precommit) {
 							// the process precommits nil
@@ -2049,16 +2019,13 @@ var _ = Describe("Process", func() {
 					acknowledge := false
 					broadcaster := processutil.BroadcasterCallbacks{
 						BroadcastProposeCallback: func(msg process.Propose) {
-							// we expect to never receive propose broadcast
-							Expect(true).ToNot(BeTrue())
+							Fail("unexpectedly received a propose broadcast")
 						},
 						BroadcastPrevoteCallback: func(msg process.Prevote) {
-							// we expect to never receive prevote broadcast
-							Expect(true).ToNot(BeTrue())
+							Fail("unexpectedly received a prevote broadcast")
 						},
 						BroadcastPrecommitCallback: func(msg process.Precommit) {
-							// we expect to never receive prevote broadcast
-							Expect(true).ToNot(BeTrue())
+							Fail("unexpectedly received a precommit broadcast")
 						},
 					}
 					f := 5 + (r.Int() % 10)
@@ -2144,7 +2111,7 @@ var _ = Describe("Process", func() {
 								BroadcastProposeCallback: nil,
 								BroadcastPrevoteCallback: nil,
 								BroadcastPrecommitCallback: func(msg process.Precommit) {
-									Expect(true).To(BeFalse())
+									Fail("unexpectedly received a precommit broadcast")
 								},
 							}
 							p := process.New(whoami, f, nil, nil, nil, nil, broadcaster, nil, nil)
@@ -2228,8 +2195,7 @@ var _ = Describe("Process", func() {
 					time.Sleep(5 * time.Millisecond)
 					select {
 					case _ = <-timeoutSignal:
-						// this should never happen
-						Expect(true).ToNot(BeTrue())
+						Fail("unexpectedly received a precommit timeout")
 					default:
 						Expect(true).To(BeTrue())
 					}
@@ -2245,7 +2211,7 @@ var _ = Describe("Process", func() {
 					Expect(timeout.Height).To(Equal(process.Height(1)))
 					Expect(timeout.Round).To(Equal(currentRound))
 				default:
-					Expect(true).ToNot(BeTrue())
+					Fail("expected to receive a precommit timeout")
 				}
 
 				// sending further messages should not schedule another timeout
@@ -2256,8 +2222,7 @@ var _ = Describe("Process", func() {
 				time.Sleep(5 * time.Millisecond)
 				select {
 				case _ = <-timeoutSignal:
-					// this should never happen
-					Expect(true).ToNot(BeTrue())
+					Fail("unexpectedly received a precommit timeout")
 				default:
 					Expect(true).To(BeTrue())
 				}
@@ -2301,8 +2266,7 @@ var _ = Describe("Process", func() {
 					time.Sleep(5 * time.Millisecond)
 					select {
 					case _ = <-timeoutSignal:
-						// this should never happen
-						Expect(true).ToNot(BeTrue())
+						Fail("unexpectedly received a precommit timeout")
 					default:
 						Expect(true).To(BeTrue())
 					}
@@ -2315,8 +2279,7 @@ var _ = Describe("Process", func() {
 				time.Sleep(5 * time.Millisecond)
 				select {
 				case _ = <-timeoutSignal:
-					// this hsould neveer happen
-					Expect(true).ToNot(BeTrue())
+					Fail("unexpectedly received a precommit timeout")
 				default:
 					Expect(true).To(BeTrue())
 				}
@@ -2360,8 +2323,7 @@ var _ = Describe("Process", func() {
 					time.Sleep(5 * time.Millisecond)
 					select {
 					case _ = <-timeoutSignal:
-						// this should never happen
-						Expect(true).ToNot(BeTrue())
+						Fail("unexpectedly received a precommit timeout")
 					default:
 						Expect(true).To(BeTrue())
 					}
@@ -2374,8 +2336,7 @@ var _ = Describe("Process", func() {
 				time.Sleep(5 * time.Millisecond)
 				select {
 				case _ = <-timeoutSignal:
-					// this should never happen
-					Expect(true).ToNot(BeTrue())
+					Fail("unexpectedly received a precommit timeout")
 				default:
 					Expect(true).To(BeTrue())
 				}
@@ -2551,25 +2512,20 @@ var _ = Describe("Process", func() {
 					loop := func() bool {
 						currentHeight := process.Height(r.Int63())
 						currentRound := process.Round(r.Int63())
-						proposedValue := processutil.RandomValue(r)
-						for proposedValue == process.NilValue {
-							proposedValue = processutil.RandomValue(r)
-						}
+						proposedValue := processutil.RandomGoodValue(r)
 						whoami := id.NewPrivKey().Signatory()
 						f := 5 + (r.Int() % 10)
 						committer := processutil.CommitterCallback{
 							Callback: func(height process.Height, value process.Value) {
-								// the process should never broadcast a commit
-								Expect(true).ToNot(BeTrue())
+								Fail("unexpectedly received a commit")
 							},
 						}
 						broadcaster := processutil.BroadcasterCallbacks{
-							// the process should not broadcast any message
 							BroadcastProposeCallback: func(msg process.Propose) {
-								Expect(true).ToNot(BeTrue())
+								Fail("unexpectedly received a propose broadcast")
 							},
 							BroadcastPrecommitCallback: func(msg process.Precommit) {
-								Expect(true).ToNot(BeTrue())
+								Fail("unexpectedly received a precommit broadcast")
 							},
 						}
 
@@ -2626,8 +2582,7 @@ var _ = Describe("Process", func() {
 						f := 5 + (r.Int() % 10)
 						committer := processutil.CommitterCallback{
 							Callback: func(height process.Height, value process.Value) {
-								// the process should never broadcast the commit
-								Expect(true).ToNot(BeTrue())
+								Fail("unexpectedly received a commit")
 							},
 						}
 						scheduler := scheduler.NewRoundRobin([]id.Signatory{id.NewPrivKey().Signatory()})
@@ -2677,8 +2632,7 @@ var _ = Describe("Process", func() {
 						f := 5 + (r.Int() % 10)
 						committer := processutil.CommitterCallback{
 							Callback: func(height process.Height, value process.Value) {
-								// the process should never broadcast the commit
-								Expect(true).ToNot(BeTrue())
+								Fail("unexpectedly received a commit")
 							},
 						}
 						validator := processutil.MockValidator{MockValid: func(process.Value) bool { return false }}
@@ -2777,7 +2731,7 @@ var _ = Describe("Process", func() {
 								proposedValue := processutil.RandomGoodValue(r)
 								committer := processutil.CommitterCallback{
 									Callback: func(height process.Height, value process.Value) {
-										Expect(true).To(BeFalse())
+										Fail("unexpectedly received a commit")
 									},
 								}
 								p := process.New(whoami, f, nil, nil, nil, nil, nil, committer, nil)
@@ -3096,16 +3050,13 @@ var _ = Describe("Process", func() {
 							acknowledge = true
 						},
 						CatchDoublePrevoteCallback: func(prevote1 process.Prevote, prevote2 process.Prevote) {
-							// this should never happen
-							Expect(true).ToNot(BeTrue())
+							Fail("unexpectedly caught prevote as a double prevote")
 						},
 						CatchDoublePrecommitCallback: func(precommit1 process.Precommit, precommit2 process.Precommit) {
-							// this should never happen
-							Expect(true).ToNot(BeTrue())
+							Fail("unexpectedly caught precommit as a double precommit")
 						},
 						CatchOutOfTurnProposeCallback: func(propose process.Propose) {
-							// this should never happen
-							Expect(true).ToNot(BeTrue())
+							Fail("unexpectedly caught propose as an out-of-turn propose")
 						},
 					}
 					scheduler := scheduler.NewRoundRobin([]id.Signatory{doubleSender})
@@ -3165,8 +3116,7 @@ var _ = Describe("Process", func() {
 					acknowledge := false
 					catcher := processutil.CatcherCallbacks{
 						CatchDoubleProposeCallback: func(propose1 process.Propose, propose2 process.Propose) {
-							// this should never happen
-							Expect(true).ToNot(BeTrue())
+							Fail("unexpectedly caught propose as a double propose")
 						},
 						CatchDoublePrevoteCallback: func(prevote1 process.Prevote, prevote2 process.Prevote) {
 							Expect(prevote1.From.Equal(&doubleSender)).To(BeTrue())
@@ -3174,12 +3124,10 @@ var _ = Describe("Process", func() {
 							acknowledge = true
 						},
 						CatchDoublePrecommitCallback: func(precommit1 process.Precommit, precommit2 process.Precommit) {
-							// this should never happen
-							Expect(true).ToNot(BeTrue())
+							Fail("unexpectedly caught precommit as a double precommit")
 						},
 						CatchOutOfTurnProposeCallback: func(propose process.Propose) {
-							// this should never happen
-							Expect(true).ToNot(BeTrue())
+							Fail("unexpectedly caught propose as an out-of-turn propose")
 						},
 					}
 					p := process.New(whoami, 33, nil, nil, nil, nil, nil, nil, catcher)
@@ -3252,12 +3200,10 @@ var _ = Describe("Process", func() {
 					acknowledge := false
 					catcher := processutil.CatcherCallbacks{
 						CatchDoubleProposeCallback: func(propose1 process.Propose, propose2 process.Propose) {
-							// this should never happen
-							Expect(true).ToNot(BeTrue())
+							Fail("unexpectedly caught propose as a double propose")
 						},
 						CatchDoublePrevoteCallback: func(prevote1 process.Prevote, prevote2 process.Prevote) {
-							// this should never happen
-							Expect(true).ToNot(BeTrue())
+							Fail("unexpectedly caught prevote as a double prevote")
 						},
 						CatchDoublePrecommitCallback: func(precommit1 process.Precommit, precommit2 process.Precommit) {
 							Expect(precommit1.From.Equal(&doubleSender)).To(BeTrue())
@@ -3265,8 +3211,7 @@ var _ = Describe("Process", func() {
 							acknowledge = true
 						},
 						CatchOutOfTurnProposeCallback: func(propose process.Propose) {
-							// this should never happen
-							Expect(true).ToNot(BeTrue())
+							Fail("unexpectedly caught propose as an out-of-turn propose")
 						},
 					}
 					p := process.New(whoami, 33, nil, nil, nil, nil, nil, nil, catcher)
@@ -3340,16 +3285,13 @@ var _ = Describe("Process", func() {
 					acknowledge := false
 					catcher := processutil.CatcherCallbacks{
 						CatchDoubleProposeCallback: func(propose1 process.Propose, propose2 process.Propose) {
-							// this should never happen
-							Expect(true).ToNot(BeTrue())
+							Fail("unexpectedly caught propose as a double propose")
 						},
 						CatchDoublePrevoteCallback: func(prevote1 process.Prevote, prevote2 process.Prevote) {
-							// this should never happen
-							Expect(true).ToNot(BeTrue())
+							Fail("unexpectedly caught prevote as a double prevote")
 						},
 						CatchDoublePrecommitCallback: func(precommit1 process.Precommit, precommit2 process.Precommit) {
-							// this should never happen
-							Expect(true).ToNot(BeTrue())
+							Fail("unexpectedly caught precommit as a double precommit")
 						},
 						CatchOutOfTurnProposeCallback: func(propose process.Propose) {
 							Expect(propose.From.Equal(&outOfTurnSender)).To(BeTrue())


### PR DESCRIPTION
In `process.go`, certain actions should be triggered upon seeing `2f+1` messages of a certain type. For example upon seeing `2f+1` Prevote `nil` messages for a certain height and round, a Precommit `nil` message should be emitted.
This is implemented in `tryPrecommitNilUponSufficientPrevotes()` of `process.go`.

However, the Precommit `nil` message is only broadcasted when there are *exactly* `2f+1` Prevote `nil` messages. This equality condition might be missed as messages of different rounds at the current height may arrive out-of-order and/or when the state is in another step. Hence when the `tryPrecommitNilUponSufficientPrevotes` function is called for the first time with `p.CurrentStep == Prevoting`, there might already be `2f+2` messages stored in `p.PrevoteLogs[p.CurrentRound]` and this node will never emit the Precommit `nil` message.

Similarly, in the function `tryTimeoutPrevoteUponSufficientPrevotes()`

Similarly, in the function `tryCommitUponSufficientPrecommits()`

# Solution
* Change `==` to `>=`
* Test scenarios in which we have `>= 2f+1` messages and we transition into the appropriate state