### PR TITLE
handle correctly invalid proposals from future round

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -741,12 +741,17 @@ func (p *Process) insertPropose(propose Propose) bool {
 		if p.broadcaster != nil {
 			p.broadcaster.BroadcastPrevote(Prevote{
 				Height: p.CurrentHeight,
-				Round:  p.CurrentRound,
+				Round:  propose.Round,
 				Value:  NilValue,
 				From:   p.whoami,
 			})
+		}
+
+		// Step to prevoting if the proposal was for the round we are currently in
+		if p.CurrentRound == propose.Round {
 			p.stepToPrevoting()
 		}
+
 		return false
 	}
 

--- a/process/process.go
+++ b/process/process.go
@@ -751,15 +751,6 @@ func (p *Process) insertPropose(propose Propose) bool {
 	// inserted the propose message to our propose logs, while explicitly marking
 	// it as invalid.
 	if propose.Value == NilValue || (p.validator != nil && !p.validator.Valid(propose.Value)) {
-		if p.broadcaster != nil {
-			p.broadcaster.BroadcastPrevote(Prevote{
-				Height: p.CurrentHeight,
-				Round:  propose.Round,
-				Value:  NilValue,
-				From:   p.whoami,
-			})
-		}
-
 		p.ProposeLogs[propose.Round] = propose
 		p.ProposeIsValid[propose.Round] = false
 		return true

--- a/process/process.go
+++ b/process/process.go
@@ -671,6 +671,7 @@ func (p *Process) tryCommitUponSufficientPrecommits(round Round) {
 
 		// Empty message logs in preparation for the new Height.
 		p.ProposeLogs = map[Round]Propose{}
+		p.ProposeIsValid = map[Round]bool{}
 		p.PrevoteLogs = map[Round]map[id.Signatory]Prevote{}
 		p.PrecommitLogs = map[Round]map[id.Signatory]Precommit{}
 		p.OnceFlags = map[Round]OnceFlag{}

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -730,7 +730,7 @@ var _ = Describe("Process", func() {
 				})
 
 				Context("when the propose message is invalid", func() {
-					It("should prevote nil and move to the precommitting step", func() {
+					It("should prevote nil and move to the prevoting step", func() {
 						f := func() bool {
 							round := processutil.RandomRound(r)
 							for round == process.InvalidRound {

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -756,7 +756,7 @@ var _ = Describe("Process", func() {
 								Height:     process.Height(1),
 								Round:      round,
 								ValidRound: process.InvalidRound,
-								Value:      processutil.RandomValue(r),
+								Value:      processutil.RandomGoodValue(r),
 								From:       scheduledProposer,
 							})
 							Expect(acknowledge).To(BeTrue())

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -901,21 +901,17 @@ var _ = Describe("Process", func() {
 
 		Context("when we receive an invalid propose", func() {
 			Context("when the propose is for a future round", func() {
-				It("should broadcast a nil prevote for the future round", func() {
+				It("should insert the proposal as invalid, but do nothing", func() {
 					loop := func() bool {
 						currentHeight := process.Height(r.Int63())
 						currentRound := process.Round(r.Int63())
 						f := 5 + r.Intn(15)
 						whoami := id.NewPrivKey().Signatory()
-						acknowledge := false
 						futureRound := currentRound + 1 + process.Round(r.Intn(10))
 						broadcaster := processutil.BroadcasterCallbacks{
 							BroadcastProposeCallback: nil,
 							BroadcastPrevoteCallback: func(prevote process.Prevote) {
-								acknowledge = true
-								Expect(prevote.Value).To(Equal(process.NilValue))
-								Expect(prevote.Round).To(Equal(futureRound))
-								Expect(prevote.Height).To(Equal(currentHeight))
+								Fail("unexpectedly received a prevote broadcast")
 							},
 							BroadcastPrecommitCallback: nil,
 						}
@@ -938,16 +934,106 @@ var _ = Describe("Process", func() {
 							ValidRound: process.InvalidRound,
 						})
 
-						// make sure we have broadcasted the prevote for future round
-						Expect(acknowledge).To(BeTrue())
-
-						// make sure that in the current round we have not yet stepped to
-						// prevoting
+						// make sure that we still are in the current round we have not yet
+						// stepped to prevoting
 						Expect(p.CurrentStep).To(Equal(process.Proposing))
 
 						return true
 					}
 					Expect(quick.Check(loop, nil)).To(Succeed())
+				})
+
+				Context("when we also receive f+1 future round messages", func() {
+					It("should prevote nil and advance to prevoting step", func() {
+						loop := func() bool {
+							currentHeight := process.Height(r.Int63())
+							currentRound := process.Round(r.Int63())
+							f := 5 + r.Intn(15)
+							whoami := id.NewPrivKey().Signatory()
+							futureRound := currentRound + 1 + process.Round(r.Intn(10))
+							acknowledge := false
+							broadcaster := processutil.BroadcasterCallbacks{
+								BroadcastProposeCallback: nil,
+								BroadcastPrevoteCallback: func(prevote process.Prevote) {
+									Expect(prevote.Value).To(Equal(process.NilValue))
+									Expect(prevote.Round).To(Equal(futureRound))
+									Expect(prevote.From).To(Equal(whoami))
+									acknowledge = true
+								},
+								BroadcastPrecommitCallback: nil,
+							}
+							// the future proposal will be invalid
+							validator := processutil.MockValidator{
+								MockValid: func(value process.Value) bool {
+									return false
+								},
+							}
+							p := process.New(whoami, f, nil, nil, nil, validator, broadcaster, nil, nil)
+
+							p.CurrentHeight = currentHeight
+							p.StartRound(currentRound)
+
+							p.Propose(process.Propose{
+								Height:     currentHeight,
+								Round:      futureRound,
+								Value:      processutil.RandomGoodValue(r),
+								From:       id.NewPrivKey().Signatory(),
+								ValidRound: process.InvalidRound,
+							})
+
+							// make sure that we still are in the current round we have not
+							// yet stepped to prevoting, and we also haven't prevoted
+							Expect(p.CurrentStep).To(Equal(process.Proposing))
+							Expect(p.CurrentRound).To(Equal(currentRound))
+							Expect(acknowledge).To(BeFalse())
+
+							// construct f future round prevotes/precommits
+							messages := make([]interface{}, f+1)
+							for t := 0; t < f+1; t++ {
+								switch r.Int() % 2 {
+								case 0:
+									msg := process.Prevote{
+										Height:    currentHeight,
+										Round:     futureRound,
+										From:      id.NewPrivKey().Signatory(),
+										Value:     processutil.RandomGoodValue(r),
+										Signature: id.Signature{},
+									}
+									messages = append(messages, msg)
+								case 1:
+									msg := process.Precommit{
+										Height:    currentHeight,
+										Round:     futureRound,
+										From:      id.NewPrivKey().Signatory(),
+										Value:     processutil.RandomGoodValue(r),
+										Signature: id.Signature{},
+									}
+									messages = append(messages, msg)
+								}
+							}
+
+							// feed those messages
+							for _, msg := range messages {
+								switch msg := msg.(type) {
+								case process.Propose:
+									p.Propose(msg)
+								case process.Prevote:
+									p.Prevote(msg)
+								case process.Precommit:
+									p.Precommit(msg)
+								}
+							}
+
+							// make sure that we are in the future round, and advanced to the
+							// prevoting step, while having prevoted
+							Expect(p.CurrentStep).To(Equal(process.Prevoting))
+							Expect(p.CurrentRound).To(Equal(futureRound))
+							Expect(acknowledge).To(BeTrue())
+
+							return true
+						}
+						Expect(quick.Check(loop, nil)).To(Succeed())
+					})
 				})
 			})
 

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -3765,16 +3765,6 @@ var _ = Describe("Process", func() {
 					p := process.New(whoami, 33, nil, scheduler, nil, nil, nil, nil, catcher)
 					p.StartRound(round)
 
-					// receive propose msg from the scheduled sender
-					propose1 := process.Propose{
-						From:   scheduledSender,
-						Height: process.Height(1),
-						Round:  round,
-						Value:  processutil.RandomValue(r),
-					}
-					p.Propose(propose1)
-					Expect(acknowledge).ToNot(BeTrue())
-
 					// receive propose from out of turn sender, must catch
 					propose2 := process.Propose{
 						From:   outOfTurnSender,

--- a/process/state.go
+++ b/process/state.go
@@ -101,6 +101,9 @@ func (state State) Clone() State {
 	for round, propose := range state.ProposeLogs {
 		cloned.ProposeLogs[round] = propose
 	}
+	for round, proposeIsValid := range state.ProposeIsValid {
+		cloned.ProposeIsValid[round] = proposeIsValid
+	}
 	for round, prevotes := range state.PrevoteLogs {
 		cloned.PrevoteLogs[round] = make(map[id.Signatory]Prevote)
 		for signatory, prevote := range prevotes {


### PR DESCRIPTION
When a proposal is inserted for the correct height and a future round, it is handled by `insertPropose` inside `process.go`. The only precondition, for such a message to be handled is that is must come from the right proposer for that round. However, an adversary can just pick a future round, when it would be the proposer. Inside `insertPropose`, the validity of the proposal is determined using a higher-level function abstracted as `Validator`.

Then a mistake arises as the validity result is applied to the current round and not to the future round that it belongs to. Hence, two issues appear:
* A Prevote `nil` for the current round is broadcasted:
```go
p.broadcaster.BroadcastPrevote(Prevote{
    Height: p.CurrentHeight,
    Round: p.CurrentRound,
    Value: NilValue,
    From: p.whoami,
}
```
However, the proposal was for a future round.
* The current step is changed to Prevoting. However, the current step should not be changed.
Note that the current step could have been anything, even Precommitting, at this point.

# Solution
* Broadcast the prevote for the future round, in this case the propose message's `propose.Round`
* Step to prevoting only if the propose message's round matches the process current round