### PR TITLE
modify condition to strictly follow paper

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -421,7 +421,7 @@ func (p *Process) tryPrevoteUponSufficientPrevotes() {
 	if !ok {
 		return
 	}
-	if propose.ValidRound == InvalidRound || propose.ValidRound >= p.CurrentRound {
+	if propose.ValidRound <= InvalidRound || propose.ValidRound >= p.CurrentRound {
 		return
 	}
 


### PR DESCRIPTION
In Algorithm 1 of the Paper, on line 28 the condition is:
```
(vr >= 0 ^ vr < round_p)
```
The actual implementation in `tryPrevoteUponSufficientPrevotes()` in `process.go`
checks the opposite and aborts the execution when the condition is not met:
```go
if propose.ValidRound == InvalidRound || propose.ValidRound >= p.CurrentRound {
    return
}
```