### PR TITLE
prevent nil value being committed

### DIFF
--- a/process/process_test.go
+++ b/process/process_test.go
@@ -2990,6 +2990,7 @@ var _ = Describe("Process", func() {
 						propose.From = signatories[0]
 						propose.Height = currentHeight
 						propose.Round = futureRound
+						propose.Value = processutil.RandomGoodValue(r)
 						messages = append(messages, propose)
 
 						// append f prevote/precommit messages


### PR DESCRIPTION
The `tryCommitUponSufficientPrecommits()` function commits the agreed upon value in case there is a valid proposal and at least `2f+1` precommits for the proposal. However, as there is no check for the value of the proposal, the `Nil` Value might be committed. This is non-desirable as the `Nil` Value has a special purpose in the protocol and signals an incomplete round. However, while honest nodes could send `2f+1` precommits with the `Nil` value if the proposer never proposed anything, an adversarial proposer, might shortly before the end of the round propose the `Nil` Value.
If the `Nil` Value is not filtered by the Validator or if no `Validator` has been specified, then the proposal will be inserted and the precommits, that were supposed to signal an empty round, suddenly cause a height change and cause the `Nil` Value to be committed.

# Solution
* If `nil` value is proposed and not caught by the `Validator` (for reasons like no validator implementation available, or if it strangely skips checking that), we prevote `nil` and step to `prevoting` step. Also, do not insert this proposal in the `ProposeLogs`, and in doing that, also avoid ever committing a `nil` value