### PR TITLE
Include height and round in the validator interface

### DIFF
--- a/process/message.go
+++ b/process/message.go
@@ -7,13 +7,18 @@ import (
 	"github.com/renproject/surge"
 )
 
+// MessageType enumerates the various types of Hyperdrive messages.
 type MessageType int8
 
 const (
-	MessageTypePropose   MessageType = 1
-	MessageTypePrevote   MessageType = 2
+	// MessageTypePropose is the message type for a propose message.
+	MessageTypePropose MessageType = 1
+	// MessageTypePrevote is the message type for a prevote message.
+	MessageTypePrevote MessageType = 2
+	// MessageTypePrecommit is the message type for a precommit message.
 	MessageTypePrecommit MessageType = 3
-	MessageTypeTimeout   MessageType = 4
+	// MessageTypeTimeout is the message type for a timeout message.
+	MessageTypeTimeout MessageType = 4
 )
 
 // String implements the Stringer interface.

--- a/process/process.go
+++ b/process/process.go
@@ -62,7 +62,7 @@ type Broadcaster interface {
 // A Validator is used to validate a proposed Value. Processes are not required
 // to agree on the validity of a Value.
 type Validator interface {
-	Valid(Value) bool
+	Valid(Height, Round, Value) bool
 }
 
 // A Committer is used to emit Values that are committed. The commitment of a
@@ -760,7 +760,7 @@ func (p *Process) insertPropose(propose Propose) bool {
 	// trace logs as it is an invalid proposal. We return true as we have in fact
 	// inserted the propose message to our propose logs, while explicitly marking
 	// it as invalid.
-	if propose.Value == NilValue || (p.validator != nil && !p.validator.Valid(propose.Value)) {
+	if propose.Value == NilValue || (p.validator != nil && !p.validator.Valid(propose.Height, propose.Round, propose.Value)) {
 		p.ProposeLogs[propose.Round] = propose
 		p.ProposeIsValid[propose.Round] = false
 		return true

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -614,7 +614,7 @@ var _ = Describe("Process", func() {
 								}
 								scheduledProposer := id.NewPrivKey().Signatory()
 								scheduler := scheduler.NewRoundRobin([]id.Signatory{scheduledProposer})
-								validator := processutil.MockValidator{MockValid: func(process.Value) bool { return true }}
+								validator := processutil.MockValidator{MockValid: func(process.Height, process.Round, process.Value) bool { return true }}
 
 								p := process.New(whoami, 33, nil, scheduler, nil, validator, broadcaster, nil, nil)
 								p.StartRound(round)
@@ -656,7 +656,7 @@ var _ = Describe("Process", func() {
 								}
 								scheduledProposer := id.NewPrivKey().Signatory()
 								scheduler := scheduler.NewRoundRobin([]id.Signatory{scheduledProposer})
-								validator := processutil.MockValidator{MockValid: func(process.Value) bool { return true }}
+								validator := processutil.MockValidator{MockValid: func(process.Height, process.Round, process.Value) bool { return true }}
 
 								p := process.New(whoami, 33, nil, scheduler, nil, validator, broadcaster, nil, nil)
 								p.StartRound(round)
@@ -702,7 +702,7 @@ var _ = Describe("Process", func() {
 								}
 								scheduledProposer := id.NewPrivKey().Signatory()
 								scheduler := scheduler.NewRoundRobin([]id.Signatory{scheduledProposer})
-								validator := processutil.MockValidator{MockValid: func(process.Value) bool { return true }}
+								validator := processutil.MockValidator{MockValid: func(process.Height, process.Round, process.Value) bool { return true }}
 
 								p := process.New(whoami, 33, nil, scheduler, nil, validator, broadcaster, nil, nil)
 								p.StartRound(round)
@@ -747,7 +747,7 @@ var _ = Describe("Process", func() {
 							}
 							scheduledProposer := id.NewPrivKey().Signatory()
 							scheduler := scheduler.NewRoundRobin([]id.Signatory{scheduledProposer})
-							validator := processutil.MockValidator{MockValid: func(process.Value) bool { return false }}
+							validator := processutil.MockValidator{MockValid: func(process.Height, process.Round, process.Value) bool { return false }}
 
 							p := process.New(whoami, 33, nil, scheduler, nil, validator, broadcaster, nil, nil)
 							p.StartRound(round)
@@ -876,7 +876,7 @@ var _ = Describe("Process", func() {
 						}
 						scheduledProposer := id.NewPrivKey().Signatory()
 						scheduler := scheduler.NewRoundRobin([]id.Signatory{scheduledProposer})
-						validator := processutil.MockValidator{MockValid: func(process.Value) bool { return true }}
+						validator := processutil.MockValidator{MockValid: func(process.Height, process.Round, process.Value) bool { return true }}
 
 						p := process.New(whoami, 33, nil, scheduler, nil, validator, broadcaster, nil, nil)
 						p.StartRound(round)
@@ -917,7 +917,7 @@ var _ = Describe("Process", func() {
 						}
 						// the future proposal will be invalid
 						validator := processutil.MockValidator{
-							MockValid: func(value process.Value) bool {
+							MockValid: func(process.Height, process.Round, process.Value) bool {
 								return false
 							},
 						}
@@ -964,7 +964,7 @@ var _ = Describe("Process", func() {
 							}
 							// the future proposal will be invalid
 							validator := processutil.MockValidator{
-								MockValid: func(value process.Value) bool {
+								MockValid: func(process.Height, process.Round, process.Value) bool {
 									return false
 								},
 							}
@@ -1055,7 +1055,7 @@ var _ = Describe("Process", func() {
 						}
 						// the future proposal will be invalid
 						validator := processutil.MockValidator{
-							MockValid: func(value process.Value) bool {
+							MockValid: func(process.Height, process.Round, process.Value) bool {
 								return false
 							},
 						}
@@ -1209,7 +1209,7 @@ var _ = Describe("Process", func() {
 										// this scheduler will always schedule the above proposer to propose
 										mockScheduler := scheduler.NewRoundRobin([]id.Signatory{scheduledProposer})
 										// mock validator that considers any proposal as valid
-										mockValidator := processutil.MockValidator{MockValid: func(process.Value) bool { return true }}
+										mockValidator := processutil.MockValidator{MockValid: func(process.Height, process.Round, process.Value) bool { return true }}
 										// this will be the proposed value
 										proposedValue := processutil.RandomValue(r)
 										for proposedValue == process.NilValue {
@@ -1275,7 +1275,7 @@ var _ = Describe("Process", func() {
 										// this scheduler will always schedule the above proposer to propose
 										mockScheduler := scheduler.NewRoundRobin([]id.Signatory{scheduledProposer})
 										// mock validator that considers any proposal as valid
-										mockValidator := processutil.MockValidator{MockValid: func(process.Value) bool { return true }}
+										mockValidator := processutil.MockValidator{MockValid: func(process.Height, process.Round, process.Value) bool { return true }}
 										// this will be the proposed value
 										proposedValue := processutil.RandomValue(r)
 										for proposedValue == process.NilValue {
@@ -1343,7 +1343,7 @@ var _ = Describe("Process", func() {
 										// this scheduler will always schedule the above proposer to propose
 										mockScheduler := scheduler.NewRoundRobin([]id.Signatory{scheduledProposer})
 										// mock validator that considers any proposal as valid
-										mockValidator := processutil.MockValidator{MockValid: func(process.Value) bool { return true }}
+										mockValidator := processutil.MockValidator{MockValid: func(process.Height, process.Round, process.Value) bool { return true }}
 										// this will be the proposed value
 										proposedValue := processutil.RandomValue(r)
 										for proposedValue == process.NilValue {
@@ -1416,7 +1416,7 @@ var _ = Describe("Process", func() {
 									// this scheduler will always schedule the above proposer to propose
 									mockScheduler := scheduler.NewRoundRobin([]id.Signatory{scheduledProposer})
 									// mock validator that considers any proposal as invalid
-									mockValidator := processutil.MockValidator{MockValid: func(process.Value) bool { return false }}
+									mockValidator := processutil.MockValidator{MockValid: func(process.Height, process.Round, process.Value) bool { return false }}
 									// this will be the proposed value
 									proposedValue := processutil.RandomValue(r)
 									for proposedValue == process.NilValue {
@@ -1486,7 +1486,7 @@ var _ = Describe("Process", func() {
 								// this scheduler will always schedule the above proposer to propose
 								mockScheduler := scheduler.NewRoundRobin([]id.Signatory{scheduledProposer})
 								// mock validator that considers any proposal as valid
-								mockValidator := processutil.MockValidator{MockValid: func(process.Value) bool { return true }}
+								mockValidator := processutil.MockValidator{MockValid: func(process.Height, process.Round, process.Value) bool { return true }}
 								// this will be the proposed value
 								proposedValue := processutil.RandomValue(r)
 								for proposedValue == process.NilValue {
@@ -1547,7 +1547,7 @@ var _ = Describe("Process", func() {
 					f := 10 + rand.Intn(40)
 					scheduledProposer := id.NewPrivKey().Signatory()
 					mockScheduler := scheduler.NewRoundRobin([]id.Signatory{scheduledProposer})
-					mockValidator := processutil.MockValidator{MockValid: func(process.Value) bool { return true }}
+					mockValidator := processutil.MockValidator{MockValid: func(process.Height, process.Round, process.Value) bool { return true }}
 					value := processutil.RandomValue(r)
 					for value == process.NilValue {
 						value = processutil.RandomValue(r)
@@ -2177,7 +2177,7 @@ var _ = Describe("Process", func() {
 					}
 					scheduledProposer := id.NewPrivKey().Signatory()
 					scheduler := scheduler.NewRoundRobin([]id.Signatory{scheduledProposer})
-					validator := processutil.MockValidator{MockValid: func(process.Value) bool { return false }}
+					validator := processutil.MockValidator{MockValid: func(process.Height, process.Round, process.Value) bool { return false }}
 
 					// instantiate a new process and its state
 					p := process.New(whoami, f, nil, scheduler, nil, validator, broadcaster, nil, nil)
@@ -2682,7 +2682,7 @@ var _ = Describe("Process", func() {
 						}
 						scheduledProposer := id.NewPrivKey().Signatory()
 						scheduler := scheduler.NewRoundRobin([]id.Signatory{scheduledProposer})
-						validator := processutil.MockValidator{MockValid: func(process.Value) bool { return true }}
+						validator := processutil.MockValidator{MockValid: func(process.Height, process.Round, process.Value) bool { return true }}
 
 						// instantiate a new process at the current round and height
 						// and at any valid step
@@ -2914,7 +2914,7 @@ var _ = Describe("Process", func() {
 								Fail("unexpectedly received a commit")
 							},
 						}
-						validator := processutil.MockValidator{MockValid: func(process.Value) bool { return false }}
+						validator := processutil.MockValidator{MockValid: func(process.Height, process.Round, process.Value) bool { return false }}
 
 						// instantiate a new process at the current round and height
 						// and at any valid step

--- a/process/processutil/processutil.go
+++ b/process/processutil/processutil.go
@@ -69,15 +69,15 @@ func (p MockProposer) Propose(height process.Height, round process.Round) proces
 // MockValidator is a mock implementation of the Validator interface
 // It always returns the MockValid value as its validation check
 type MockValidator struct {
-	MockValid func(value process.Value) bool
+	MockValid func(height process.Height, round process.Round, value process.Value) bool
 }
 
 // Valid implements the validation behaviour as required by the Validator interface
 // The MockValidator's valid method does not take into consideration the
 // received propose message, but simply returns the MockValid value as its
 // validation check
-func (v MockValidator) Valid(value process.Value) bool {
-	return v.MockValid(value)
+func (v MockValidator) Valid(height process.Height, round process.Round, value process.Value) bool {
+	return v.MockValid(height, round, value)
 }
 
 // CatcherCallbacks provide callback functions to test the Catcher interface

--- a/replica/replica_test.go
+++ b/replica/replica_test.go
@@ -140,7 +140,7 @@ var _ = Describe("Replica", func() {
 				},
 				// Validator
 				processutil.MockValidator{
-					MockValid: func(value process.Value) bool {
+					MockValid: func(_ process.Height, _ process.Round, value process.Value) bool {
 						// if this is a malicious replica, but less than f total malicious
 						if validationFn != nil && replicaIndex < f {
 							return validationFn(value)


### PR DESCRIPTION
The `height` and `round` values will be used by the validator calculate the appropriate timeout from the linear timer and set those timeouts for its context.