### PR TITLE
Constructing with a given height

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -135,6 +135,34 @@ func New(
 	committer Committer,
 	catcher Catcher,
 ) Process {
+	return NewWithCurrentHeight(
+		whoami,
+		DefaultHeight,
+		f,
+		timer,
+		scheduler,
+		proposer,
+		validator,
+		broadcaster,
+		committer,
+		catcher,
+	)
+}
+
+// NewWithCurrentHeight returns a new Process that starts at the given height
+// with empty message logs.
+func NewWithCurrentHeight(
+	whoami id.Signatory,
+	height Height,
+	f int,
+	timer Timer,
+	scheduler Scheduler,
+	proposer Proposer,
+	validator Validator,
+	broadcaster Broadcaster,
+	committer Committer,
+	catcher Catcher,
+) Process {
 	return Process{
 		whoami: whoami,
 		f:      uint64(f),
@@ -148,7 +176,7 @@ func New(
 		committer:   committer,
 		catcher:     catcher,
 
-		State: DefaultState(),
+		State: DefaultState().WithCurrentHeight(height),
 	}
 }
 

--- a/process/state.go
+++ b/process/state.go
@@ -8,6 +8,13 @@ import (
 	"github.com/renproject/surge"
 )
 
+var (
+	// DefaulHeight is set to 1, because the genesis block is assumed to exist
+	// at Height 0.
+	DefaultHeight = Height(1)
+	DefaultRound  = Round(0)
+)
+
 // The State of a Process. It should be saved after every method call on the
 // Process, but should not be saved during method calls (interacting with the
 // State concurrently is unsafe). It is worth noting that the State does not
@@ -50,13 +57,11 @@ type State struct {
 	TraceLogs map[Round]map[id.Signatory]bool
 }
 
-// DefaultState returns a State with all fields set to their default values. The
-// Height default to 1, because the genesis block is assumed to exist at Height
-// 0.
+// DefaultState returns a State with all fields set to their default values.
 func DefaultState() State {
 	return State{
-		CurrentHeight: 1, // Skip genesis.
-		CurrentRound:  0,
+		CurrentHeight: DefaultHeight,
+		CurrentRound:  DefaultRound,
 		CurrentStep:   Proposing,
 		LockedValue:   NilValue,
 		LockedRound:   InvalidRound,

--- a/replica/opt.go
+++ b/replica/opt.go
@@ -2,6 +2,7 @@ package replica
 
 import (
 	"github.com/renproject/hyperdrive/mq"
+	"github.com/renproject/hyperdrive/process"
 
 	"go.uber.org/zap"
 )
@@ -9,6 +10,7 @@ import (
 // Options represent the options for a Hyperdrive Replica
 type Options struct {
 	Logger           *zap.Logger
+	StartingHeight   process.Height
 	MessageQueueOpts mq.Options
 }
 
@@ -20,6 +22,7 @@ func DefaultOptions() Options {
 	}
 	return Options{
 		Logger:           logger,
+		StartingHeight:   process.DefaultHeight,
 		MessageQueueOpts: mq.DefaultOptions(),
 	}
 }
@@ -27,6 +30,12 @@ func DefaultOptions() Options {
 // WithLogger updates the logger used in the Replica with the provided logger
 func (opts Options) WithLogger(logger *zap.Logger) Options {
 	opts.Logger = logger
+	return opts
+}
+
+// WithStartingHeight updates the height that the Replica will start at
+func (opts Options) WithStartingHeight(height process.Height) Options {
+	opts.StartingHeight = height
 	return opts
 }
 

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -53,8 +53,9 @@ func New(
 ) *Replica {
 	f := len(signatories) / 3
 	scheduler := scheduler.NewRoundRobin(signatories)
-	proc := process.New(
+	proc := process.NewWithCurrentHeight(
 		whoami,
+		opts.StartingHeight,
 		f,
 		linearTimer,
 		scheduler,


### PR DESCRIPTION
This PR adds the feature of being able to construct a replica that will start at a given height. Using this feature also fixes a problem that can occur when trying to start a replica at a later height (for instance if blocks are being stored to disk, and consensus is restarted after a crash, you would want to start from the height after the latest stored block). The problem is as follows. The usage code will usually take the form
```go
replica := replica.New(...)

...

go replica.Run(ctx)
replica.ResetHeight(latestHeight + 1)
```
The call to `ResetHeight` will simply add a message to the message queue, to be eventually processed by the event loop in `replica.Run`. However, `replica.Run` before entering the event loop will call `process.Start` which will run proposal logic and hence if the process is the current proposer for height 1 round 0 it will send out a proposal, which we want to avoid but cannot, as this will always happen before the reset height message can be processed. This can cause consensus to halt in some situations. Using a constructor that allows the process to start at the desired height resolves this issue.