### PR TITLE
Fix deadlock when getting state

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -8,6 +8,7 @@ package process
 
 import (
 	"fmt"
+	"sync/atomic"
 
 	"github.com/renproject/id"
 	"github.com/renproject/surge"
@@ -315,7 +316,7 @@ func (p *Process) StartRound(round Round) {
 	// sequence. We do not have special methods dedicated to change the current
 	// Round, or changing the current Step to Proposing, because StartRound is
 	// the only location where this logic happens.
-	p.CurrentRound = round
+	atomic.StoreInt64((*int64)(&p.CurrentRound), int64(round))
 	p.CurrentStep = Proposing
 
 	// If we are not the proposer, then we trigger the propose timeout.
@@ -707,7 +708,7 @@ func (p *Process) tryCommitUponSufficientPrecommits(round Round) {
 		if scheduler != nil {
 			p.scheduler = scheduler
 		}
-		p.CurrentHeight++
+		atomic.AddInt64((*int64)(&p.CurrentHeight), 1)
 
 		// Reset lockedRound, lockedValue, validRound, and validValue to initial
 		// values.

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -244,7 +244,7 @@ func (replica Replica) Round() process.Round {
 }
 
 func (replica *Replica) filterHeight(height process.Height) bool {
-	return height >= replica.proc.CurrentHeight
+	return height >= replica.Height()
 }
 
 func (replica *Replica) flush() {

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -221,7 +221,7 @@ func (replica *Replica) TimeoutPrecommit(ctx context.Context, timeout timer.Time
 // NOTE: All messages that are currently in the message queue for heights less
 // than the given height will be dropped.
 func (replica *Replica) ResetHeight(ctx context.Context, newHeight process.Height, signatories []id.Signatory) {
-	if newHeight <= replica.proc.State.CurrentHeight {
+	if newHeight <= replica.Height() {
 		return
 	}
 	message := ResetHeightMessage{
@@ -250,7 +250,7 @@ func (replica *Replica) filterHeight(height process.Height) bool {
 func (replica *Replica) flush() {
 	for {
 		n := replica.mq.Consume(
-			replica.proc.CurrentHeight,
+			replica.Height(),
 			replica.proc.Propose,
 			replica.proc.Prevote,
 			replica.proc.Precommit,

--- a/replica/replica_test.go
+++ b/replica/replica_test.go
@@ -825,11 +825,7 @@ var _ = Describe("Replica", func() {
 
 						// if its not yet killed
 						if _, isKilled := killedReplicas[uint8(id)]; !isKilled {
-							var err error
-							intermTargetHeight, _, _, err = replicas[id].State(context.Background())
-							if err != nil {
-								panic(err)
-							}
+							intermTargetHeight = replicas[id].Height()
 
 							// kill the replica
 							killedReplicas[uint8(id)] = true


### PR DESCRIPTION
In #104 a race condition was fixed but a new problem was introduced: if the hyperdrive process is proposing/validating/committing (which in practice can take some time since we often make network calls during validating) then a call to `Replica.State` will be blocked. This can cause a deadlock if a call to `Replica.State` needs to return before validation can finish, which is a scenario that has been encountered in practice.

This PR proposes a solution to this problem. In general, there could have been three strategies to solve the original race condition:
1. Atomic operations
2. Mutex protecting the state
3. Handling state requests in the event loop

#104 opted for option 3. Obviously this won't work given the above mentioned problem. I claim that using mutexes is functionally the same but strictly worse than using atomic operations. The presented solution using atomic operations is not perfect though: if future changes are made to the code it will need to be remembered that these state variables need to be accessed atomically, which could be easily forgotten. Usually in this case a getter and setter could be used on private members but the members are public for reasons of marshalling, so this option is not available. I think the solution proposed in this PR is still acceptable as future changes that forget to use atomic operations should in theory be caught by the race checker, and I cannot think of a better solution.